### PR TITLE
chore: terminology rename + progress log

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Run `make help` to see all available targets.
 #
 # Conventions:
-#   exp         — one-off lessons in scripts/ (discovery-based, no Makefile edit per script)
+#   exp         — one-off experiments in scripts/ (discovery-based, no Makefile edit per script)
 #   app         — the main SkyCop pipeline (scaffolded alongside skycop/ package)
 #   test/lint   — quality gates (scaffolded with the package)
 #

--- a/docs/design.md
+++ b/docs/design.md
@@ -28,7 +28,7 @@ Companion to `docs/REQUIREMENTS.md`. Requirements answer *what* the system does;
 
 **Design goals**
 - **Reproducibility.** Anyone with Docker + an NVIDIA GPU should run `make setup && make up && make exp N=04` and get the same behaviour. Seeded RNGs, pinned deps, bind-mounted source, no host installs.
-- **Teachability.** The repo reads top-to-bottom: `docs/REQUIREMENTS.md` explains the mission, `docs/design.md` (this file) explains the architecture, `scripts/NN_*.py` are progressively richer lessons, `skycop/` is the library those lessons compose. A senior reviewer should be able to skim and understand the whole in ~15 minutes.
+- **Teachability.** The repo reads top-to-bottom: `docs/REQUIREMENTS.md` explains the mission, `docs/design.md` (this file) explains the architecture, `scripts/NN_*.py` are progressively richer experiments, `skycop/` is the library those experiments compose. A senior reviewer should be able to skim and understand the whole in ~15 minutes.
 - **Hot iteration.** Edits on the host must be live inside the container without a rebuild. CARLA loop times are 30–60 s per cold start; adding a rebuild step on top is unacceptable for research-y work.
 - **Scale-ready, not scaled.** The architecture should accommodate the full requirement set (CV pipeline, dashboard, scoring) without demanding it up front. No YAGNI abstractions.
 
@@ -58,7 +58,7 @@ SkyCop/
 ├── configs/                # yaml config files loaded by skycop.config.load(...)
 │   ├── default.yaml        # scene + carla + camera defaults
 │   └── altitude.yaml       # altitude controller thresholds
-├── scripts/                # lessons (01_hello_world, 02_drone_view, ...)
+├── scripts/                # experiments (01_hello_world, 02_drone_view, ...)
 ├── tests/                  # pytest — pure logic only; no CARLA in CI-style paths
 ├── docs/
 │   ├── REQUIREMENTS.md     # what the system does
@@ -129,7 +129,7 @@ Future additions: `control.pid` (SIM-15..18), `control.safety` (depth raycast + 
 
 ### `skycop.dashboard`
 
-- `MJPEGServer(title, hud, html=None)` — Flask streamer, daemon-threaded. `.push(frame)` from the CARLA loop, `.app` exposed for scripts that want to attach extra routes (e.g. lesson 02's keyboard capture).
+- `MJPEGServer(title, hud, html=None)` — Flask streamer, daemon-threaded. `.push(frame)` from the CARLA loop, `.app` exposed for scripts that want to attach extra routes (e.g. experiment 02's keyboard capture).
 
 Future: `dashboard.streamlit`, `dashboard.events` (WebSocket event bus per §7 of requirements).
 
@@ -155,11 +155,11 @@ Per requirements §2.2, every tick runs three phases in order:
 2. **CV tracking** (YOLOv8 + ByteTrack + fingerprint).
 3. **Control** (PID + camera transform apply).
 
-Currently lessons 03/04 run only phases 1-like (raycast) and 3 (camera placement). CV lands with the Detection milestone.
+Currently experiments 03/04 run only phases 1-like (raycast) and 3 (camera placement). CV lands with the Detection milestone.
 
 **Key invariants already enforced by the package:**
 
-- **One client ticks.** All lessons connect as the sole ticker. Multi-client scenarios are out of scope.
+- **One client ticks.** All experiments connect as the sole ticker. Multi-client scenarios are out of scope.
 - **Synchronous mode is scoped.** The `synchronous_mode(world, dt)` context manager is the only place sync mode is toggled. SIGTERM bypasses it (a known caveat) so we additionally provide documentation and a manual reset idiom for ops.
 - **Sensors destroyed before vehicles.** `destroy_all(actors)` iterates in reverse-spawn order; sensors with `.is_listening` are `.stop()`-ed first. This closes the leak documented in caveat §6.
 - **Fixed 20 FPS.** `fixed_delta_seconds = 0.05`, CARLA server launched with `-benchmark -fps=20` to match. Both settings must agree (caveat §15).
@@ -207,7 +207,7 @@ Each tick, casts `N=8` horizontal rays from the drone's previous-Z position outw
 
 ## 9. Dashboard Surface
 
-Lessons run their own lightweight surface: `MJPEGServer` serves `/` (HTML with embedded stream) and `/stream` (multipart JPEG). Lesson 02 adds a `/keys` POST route on the same Flask app for keyboard capture — demonstrates the "attach extra routes" extension pattern.
+Experiments run their own lightweight surface: `MJPEGServer` serves `/` (HTML with embedded stream) and `/stream` (multipart JPEG). Experiment 02 adds a `/keys` POST route on the same Flask app for keyboard capture — demonstrates the "attach extra routes" extension pattern.
 
 The real §7 dashboard (Streamlit + Leaflet + WebSocket event bus) will sit alongside, reusing the MJPEG feed. Design for that lands with the Dashboard milestone.
 
@@ -223,10 +223,10 @@ Current coverage:
 - `test_config.py` — OmegaConf merger: file overlays, dot-list overrides, missing-config errors.
 
 **What we explicitly do not test:**
-- CARLA integration behaviours (spawns, raycast hits). Mocking CARLA deeply is expensive and brittle; we rely on end-to-end runs of the lesson scripts instead.
-- Flask routes. MJPEG is exercised whenever a lesson runs; separate route tests would be over-engineering for a demo.
+- CARLA integration behaviours (spawns, raycast hits). Mocking CARLA deeply is expensive and brittle; we rely on end-to-end runs of the experiment scripts instead.
+- Flask routes. MJPEG is exercised whenever an experiment runs; separate route tests would be over-engineering for a demo.
 
-**E2E verification** is manual: run each lesson against a live CARLA server, check Flask serves HTTP 200, verify the frame stream is live. Documented in the PR descriptions, not automated. Added to the test strategy if a CV regression workflow demands it.
+**E2E verification** is manual: run each experiment against a live CARLA server, check Flask serves HTTP 200, verify the frame stream is live. Documented in the PR descriptions, not automated. Added to the test strategy if a CV regression workflow demands it.
 
 ---
 
@@ -234,7 +234,7 @@ Current coverage:
 
 **Entrypoint contract: everything through `make`.** Operators never invoke `docker compose`, `pip`, or `python3` directly. The Makefile is organised into six sections — Lifecycle, Observability, Experiments, Application, Dev, World Control — and `make help` prints them.
 
-**Experiments are discovery-based.** `make exp N=NN` fuzzy-matches `scripts/NN_*.py`, so adding a new lesson needs no Makefile edit. `make exp-list` shows what's available.
+**Experiments are discovery-based.** `make exp N=NN` fuzzy-matches `scripts/NN_*.py`, so adding a new experiment needs no Makefile edit. `make exp-list` shows what's available.
 
 **Releases are commit-grained, not tagged.** For a demo we don't need semver. Each meaningful feature lands as a focused commit; the git history is the changelog. (This document's Design Log complements it with *why* notes.)
 
@@ -264,13 +264,13 @@ The Traffic Manager's hybrid-physics mode anchors its radius on `role_name='hero
 
 **Status:** Decided · **Date:** 2026-04-20
 
-Sync mode is owned by `skycop.sim.synchronous_mode()` (context manager). Destroy order is owned by `skycop.sim.destroy_all()`. Seed setting is per-script since the RNGs are created there. No single "engine" class wraps the loop — each lesson owns its tick loop explicitly so the control flow is readable top-to-bottom. When the application's `main.py` lands, it will introduce a thin `Mission` orchestrator, but not an engine abstraction.
+Sync mode is owned by `skycop.sim.synchronous_mode()` (context manager). Destroy order is owned by `skycop.sim.destroy_all()`. Seed setting is per-script since the RNGs are created there. No single "engine" class wraps the loop — each experiment owns its tick loop explicitly so the control flow is readable top-to-bottom. When the application's `main.py` lands, it will introduce a thin `Mission` orchestrator, but not an engine abstraction.
 
 ### D-05 · Dashboard: MJPEG now, Streamlit later
 
 **Status:** Decided · **Date:** 2026-04-20
 
-Streamlit is the target per DB-10. For lessons 01–04, just a live camera feed is enough; MJPEG keeps the first few lessons dependency-light and avoids Streamlit boilerplate. Streamlit lands with the Dashboard milestone and will consume the same MJPEG feed plus the WebSocket event bus.
+Streamlit is the target per DB-10. For experiments 01–04, just a live camera feed is enough; MJPEG keeps the first few experiments dependency-light and avoids Streamlit boilerplate. Streamlit lands with the Dashboard milestone and will consume the same MJPEG feed plus the WebSocket event bus.
 
 ### D-06 · Commit grain: focused commits, no tags
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,0 +1,56 @@
+# SkyCop — Progress Log
+
+Live state of the project: which milestones are closed, which experiments have landed, what's next. Updated inside the branch that closes each unit of work — never as a stale afterthought.
+
+**Last updated:** 2026-04-20
+
+**Legend:** ✅ complete · 🔨 in progress · ⬜ planned
+
+---
+
+## Milestones
+
+Mirrors `REQUIREMENTS.md §14`. Each milestone is closed when its Definition of Done is met and the experiments listed under "evidence" have landed.
+
+| Phase | Status | DoD (abbrev.) | Evidence |
+|---|---|---|---|
+| Environment | ✅ | Town10, 50 NPCs, suspect, aerial camera streaming, adaptive altitude | exp 01–04 |
+| Detection | 🔨 | YOLOv8 fine-tuned (VisDrone + CARLA synthetic), ByteTrack integrated, suspect tracked at 80 km/h, mAP ≥ 85% | exp 05–08 planned |
+| Suspect AI | ⬜ | 4-state FSM, dispatch / CCTV / witness events, parking lot pre-populated | — |
+| Re-ID | ⬜ | Fingerprint on first detection, occlusion recovery, parking-lot identification with confidence | — |
+| Dashboard | ⬜ | Streamlit live, manual mode playable, scoring, debrief | — |
+| Polish | ⬜ | Demo video, README, eval JSON, Docker tested, architecture diagram | — |
+
+## Experiments
+
+One row per `scripts/NN_*.py`. "Produces" names the durable artifact the experiment hands to the next step (training data, weights, metrics) — not transient state.
+
+| # | Script | Purpose | Status | Produces |
+|---|---|---|---|---|
+| 01 | `hello_world` | Connect, spawn vehicle, capture one frame | ✅ | `output/01_hello_world.png` |
+| 02 | `drone_view` | Free-fly drone via Flask keyboard (smoke test for the spectator + MJPEG pipeline) | ✅ | — (interactive) |
+| 03 | `suspect_and_traffic` | 50 NPCs + reckless suspect, fixed-altitude aerial follow | ✅ | — |
+| 04 | `adaptive_altitude` | SIM-11..14: adaptive altitude via `world.cast_ray()`, hybrid physics anchored on hero | ✅ | — |
+| 05 | `collect_dataset` | Sweep drone pitch/alt/yaw/weather; RGB + instance-seg → YOLO-format labels | ⬜ | `output/dataset/` + `dataset_manifest.json` |
+| 06 | `yolo_baseline` | Pretrained YOLOv8s on our frames → measure mAP; demonstrates the domain gap | ⬜ | `output/baseline/metrics.json` |
+| 07 | `finetune_yolo` | Fine-tune YOLOv8s on VisDrone warm-start + CARLA synthetic | ⬜ | `output/weights/best.pt` |
+| 08 | `yolo_inloop` | Drop fine-tuned weights into the live pipeline; boxes + IDs overlaid on MJPEG | ⬜ | — |
+| 09 | `mission_tracer` | First end-to-end mission slice: dispatch → detect → track → mission-end (stub tracking / fingerprint) | ⬜ | — |
+
+## Currently
+
+- [x] Terminology rename (`lesson` → `experiment`) and this progress log (#1)
+- [ ] **Exp 05 — synthetic dataset collection** (next)
+- [ ] Exp 06 — baseline pretrained inference
+- [ ] Exp 07 — fine-tune on VisDrone + CARLA synthetic
+- [ ] Exp 08 — in-loop inference with fine-tuned weights
+- [ ] Exp 09 — first end-to-end mission (tracer bullet)
+
+## Log
+
+Reverse chronological. One line per landed PR. Commit SHA linked where relevant.
+
+- **2026-04-20** · `4e027f5` Add `docs/design.md` — living application design record
+- **2026-04-20** · `03b028c` Add adaptive altitude controller + OmegaConf configs (exp 04)
+- **2026-04-20** · `634c660` Restructure around `skycop/` package with pyproject-driven deps (exps 01–03 refactored)
+- **2026-04-19** · `5815c09` Initial project setup

--- a/scripts/01_hello_world.py
+++ b/scripts/01_hello_world.py
@@ -1,5 +1,5 @@
 """
-Lesson 01 — Hello CARLA World
+Experiment 01 — Hello CARLA World
 
 Connects to the CARLA server, prints world info, spawns a vehicle with
 an RGB camera, captures one frame using synchronous mode, and saves it.

--- a/scripts/02_drone_view.py
+++ b/scripts/02_drone_view.py
@@ -1,5 +1,5 @@
 """
-Lesson 02 — Drone View
+Experiment 02 — Drone View
 
 Fly around the CARLA world as a drone controlled from your browser.
 Open http://localhost:5000 to see the live camera feed and use keyboard to move.
@@ -54,7 +54,7 @@ def update_keys():
 HTML_PAGE = """<!DOCTYPE html>
 <html>
 <head>
-<title>SkyCop — Lesson 02 · Drone View</title>
+<title>SkyCop — Experiment 02 · Drone View</title>
 <style>
   * { margin: 0; padding: 0; box-sizing: border-box; }
   body { background: #111; color: #eee; font-family: monospace; overflow: hidden; }
@@ -287,7 +287,7 @@ def carla_loop(server: MJPEGServer):
 
 
 def main():
-    server = MJPEGServer(title="SkyCop — Lesson 02", html=HTML_PAGE)
+    server = MJPEGServer(title="SkyCop — Experiment 02", html=HTML_PAGE)
     # Add keyboard input route on the same Flask app.
     server.app.add_url_rule("/keys", "update_keys", update_keys, methods=["POST"])
     server.start(port=5000)

--- a/scripts/03_suspect_and_traffic.py
+++ b/scripts/03_suspect_and_traffic.py
@@ -1,5 +1,5 @@
 """
-Lesson 03 — Suspect + Traffic
+Experiment 03 — Suspect + Traffic
 
 Closes the Environment milestone:
   - Town10HD_Opt loaded
@@ -99,8 +99,8 @@ def run(server: MJPEGServer, cfg):
 def main():
     cfg = load("default")
     server = MJPEGServer(
-        title="SkyCop — Lesson 03",
-        hud=f"Lesson 03 · fixed-altitude follow @ {cfg.camera.altitude:.0f}m",
+        title="SkyCop — Experiment 03",
+        hud=f"Experiment 03 · fixed-altitude follow @ {cfg.camera.altitude:.0f}m",
     )
     server.start(port=5000)
     time.sleep(0.3)

--- a/scripts/04_adaptive_altitude.py
+++ b/scripts/04_adaptive_altitude.py
@@ -1,7 +1,7 @@
 """
-Lesson 04 — Adaptive Altitude
+Experiment 04 — Adaptive Altitude
 
-Builds on lesson 03 and layers in SIM-11..14:
+Builds on experiment 03 and layers in SIM-11..14:
   - Aerial camera height adapts each tick using world.cast_ray()
   - Lateral ring of rays detects buildings within 20m → climb
   - Downward ray measures rooftop height → ensure 12m clearance
@@ -130,8 +130,8 @@ def run(server: MJPEGServer, cfg):
 def main():
     cfg = load("default", "altitude")
     server = MJPEGServer(
-        title="SkyCop — Lesson 04",
-        hud=f"Lesson 04 · adaptive altitude [{cfg.altitude.min_m:.0f}–{cfg.altitude.max_m:.0f}m]",
+        title="SkyCop — Experiment 04",
+        hud=f"Experiment 04 · adaptive altitude [{cfg.altitude.min_m:.0f}–{cfg.altitude.max_m:.0f}m]",
     )
     server.start(port=5000)
     time.sleep(0.3)

--- a/skycop/dashboard/mjpeg.py
+++ b/skycop/dashboard/mjpeg.py
@@ -2,7 +2,7 @@
 
 Usage:
 
-    server = MJPEGServer(title="Lesson 03 — suspect follow")
+    server = MJPEGServer(title="Experiment 03 — suspect follow")
     server.start(port=5000)
     # ... in a CARLA loop:
     server.push(frame_bgr)


### PR DESCRIPTION
## Summary

- Rename `Lesson N` → `Experiment N` across script docstrings, MJPEG HUDs, `skycop/dashboard/mjpeg.py` example, `docs/design.md` prose, and a Makefile comment. The tooling surface (`make exp`, `make exp-list`) was already on "experiment" — this brings the written content in line.
- Add `docs/progress.md` as a live state record: milestone status table, per-experiment table, "Currently" checklist, reverse-chronological log. Updated inside the branch that closes each unit from now on.

Closes #1

## Test plan

- [x] `grep -rI '[Ll]esson' .` returns no hits across tracked sources
- [x] `make test` — 17/17 pass
- [x] `make lint` — clean
- [x] `docs/progress.md` reflects current reality (exps 01–04 ✅, Detection 🔨, rest ⬜)
- [ ] Reviewer sanity check on the experiment plan listed in `progress.md` before exp 05 branch opens