### PR TITLE
exp 05: capture CARLA pursuit eval holdout

### DIFF
--- a/configs/eval_capture.yaml
+++ b/configs/eval_capture.yaml
@@ -1,0 +1,14 @@
+# CARLA pursuit eval holdout — exp 05.
+# Layered on top of configs/default.yaml (which provides scene + carla + camera).
+
+eval_capture:
+  target_frames: 200          # stop once this many frames have ≥1 valid label
+  subsample_every: 10         # capture every Nth tick (20 FPS → 2 Hz at N=10)
+  max_ticks: 6000             # hard cap (~5 min at 20 FPS)
+  output_dir: /app/output/eval/carla_eval
+  min_bbox_pixel: 20          # drop boxes below this side length
+  min_visibility: 0.3         # actor_pixels / bbox_area ≥ this to keep box
+  jpeg_quality: 92            # higher than MJPEG default; this is a permanent artifact
+
+  # Override default suspect role_name='hero' is still used so TM hybrid physics
+  # anchors correctly during the pursuit.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -15,7 +15,7 @@ Mirrors `REQUIREMENTS.md §14`. Each milestone is closed when its Definition of 
 | Phase | Status | DoD (abbrev.) | Evidence |
 |---|---|---|---|
 | Environment | ✅ | Town10, 50 NPCs, suspect, aerial camera streaming, adaptive altitude | exp 01–04 |
-| Detection | 🔨 | YOLOv8s fine-tuned (VisDrone warm-start, CARLA holdout eval), ByteTrack integrated, mAP ≥ 85% on holdout | exp 05 ✅ · exp 06–08 planned |
+| Detection | 🔨 | YOLOv8s fine-tuned on 4 classes (car/van/truck/bus), ByteTrack integrated, mAP ≥ 85% on CARLA holdout | exp 05 ✅ · exp 06–08 planned |
 | Suspect AI | ⬜ | 4-state FSM, dispatch / CCTV / witness events, parking lot pre-populated | — |
 | Re-ID | ⬜ | Fingerprint on first detection, occlusion recovery, parking-lot identification with confidence | — |
 | Dashboard | ⬜ | Streamlit live, manual mode playable, scoring, debrief | — |
@@ -42,7 +42,7 @@ One row per `scripts/NN_*.py`. "Produces" names the durable artifact the experim
 
 ## Currently
 
-- [x] Exp 05 — CARLA pursuit eval holdout (200 frames, 4 of 5 classes represented)
+- [x] Exp 05 — CARLA pursuit eval holdout (200 frames, all 4 classes represented)
 - [ ] **Exp 06 — VisDrone warm-start fine-tune + mAP on holdout** (next)
 - [ ] Exp 07 — fine-tuned weights in live pipeline
 - [ ] Exp 08 — ByteTrack integration
@@ -51,8 +51,11 @@ One row per `scripts/NN_*.py`. "Produces" names the durable artifact the experim
 
 ### Known gaps / debt
 
-- **No motorcycle examples in the exp 05 eval holdout.** CARLA Traffic Manager cannot autopilot 2-wheelers, so the 50 NPC spawns are 4-wheel-only and the suspect is too. If motorcycle detection becomes important to the mission, spawn a handful of parked motorcycles (`set_simulate_physics(False)`) or drive one manually, then regenerate a motorcycle-focused eval slice. Not blocking exp 06.
 - **`dropped_unknown_class: 9423`** in the manifest is not error count — it's a per-frame sum of non-vehicle Unreal mesh component IDs the extractor correctly filtered out (roads, buildings, signs). Could be optimised by pre-filtering on the semantic-label R channel; cheap to do but not worth doing until profiling shows capture is a bottleneck.
+
+### Deliberate scope choices
+
+- **4-class taxonomy — motorcycles excluded.** CARLA's Traffic Manager cannot autopilot 2-wheelers, so our pursuit scenes produce zero motorcycle training or eval data. Carrying a class we can neither train nor evaluate on is worse than dropping it; `skycop.cv.vehicle_classes` documents how to reinstate "motorcycle" if that constraint goes away.
 
 ## Log
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -15,7 +15,7 @@ Mirrors `REQUIREMENTS.md §14`. Each milestone is closed when its Definition of 
 | Phase | Status | DoD (abbrev.) | Evidence |
 |---|---|---|---|
 | Environment | ✅ | Town10, 50 NPCs, suspect, aerial camera streaming, adaptive altitude | exp 01–04 |
-| Detection | 🔨 | YOLOv8 fine-tuned (VisDrone + CARLA synthetic), ByteTrack integrated, suspect tracked at 80 km/h, mAP ≥ 85% | exp 05–08 planned |
+| Detection | 🔨 | YOLOv8s fine-tuned (VisDrone warm-start, CARLA holdout eval), ByteTrack integrated, mAP ≥ 85% on holdout | exp 05 ✅ · exp 06–08 planned |
 | Suspect AI | ⬜ | 4-state FSM, dispatch / CCTV / witness events, parking lot pre-populated | — |
 | Re-ID | ⬜ | Fingerprint on first detection, occlusion recovery, parking-lot identification with confidence | — |
 | Dashboard | ⬜ | Streamlit live, manual mode playable, scoring, debrief | — |
@@ -23,7 +23,7 @@ Mirrors `REQUIREMENTS.md §14`. Each milestone is closed when its Definition of 
 
 ## Experiments
 
-One row per `scripts/NN_*.py`. "Produces" names the durable artifact the experiment hands to the next step (training data, weights, metrics) — not transient state.
+One row per `scripts/NN_*.py`. "Produces" names the durable artifact the experiment hands to the next step.
 
 | # | Script | Purpose | Status | Produces |
 |---|---|---|---|---|
@@ -31,25 +31,35 @@ One row per `scripts/NN_*.py`. "Produces" names the durable artifact the experim
 | 02 | `drone_view` | Free-fly drone via Flask keyboard (smoke test for the spectator + MJPEG pipeline) | ✅ | — (interactive) |
 | 03 | `suspect_and_traffic` | 50 NPCs + reckless suspect, fixed-altitude aerial follow | ✅ | — |
 | 04 | `adaptive_altitude` | SIM-11..14: adaptive altitude via `world.cast_ray()`, hybrid physics anchored on hero | ✅ | — |
-| 05 | `collect_dataset` | Sweep drone pitch/alt/yaw/weather; RGB + instance-seg → YOLO-format labels | ⬜ | `output/dataset/` + `dataset_manifest.json` |
-| 06 | `yolo_baseline` | Pretrained YOLOv8s on our frames → measure mAP; demonstrates the domain gap | ⬜ | `output/baseline/metrics.json` |
-| 07 | `finetune_yolo` | Fine-tune YOLOv8s on VisDrone warm-start + CARLA synthetic | ⬜ | `output/weights/best.pt` |
-| 08 | `yolo_inloop` | Drop fine-tuned weights into the live pipeline; boxes + IDs overlaid on MJPEG | ⬜ | — |
-| 09 | `mission_tracer` | First end-to-end mission slice: dispatch → detect → track → mission-end (stub tracking / fingerprint) | ⬜ | — |
+| 05 | `capture_eval_set` | CARLA pursuit eval holdout — 200 frames + YOLO labels + manifest | ✅ | `output/eval/carla_eval/` (200 jpg + 200 txt + manifest.json) |
+| 06 | `finetune_yolo` | YOLOv8s fine-tune on VisDrone warm-start; scores pretrained + fine-tuned on exp 05 holdout | ⬜ | `output/weights/best.pt` + `output/eval/metrics.json` |
+| 07 | `yolo_inloop` | Fine-tuned weights in live pipeline, boxes + conf overlaid on MJPEG | ⬜ | — |
+| 08 | `bytetrack` | Multi-object tracker on top of detections — persistent track IDs | ⬜ | — |
+| 09 | `fingerprint` | HSV colour + geometry attributes per track (CV-11..16) | ⬜ | — |
+| 10 | `mission_tracer` | First end-to-end mission slice: dispatch → detect → track → mission-end | ⬜ | — |
+| 11 | `dashboard_scoring` | Streamlit + event bus + scoring + debrief | ⬜ | — |
+| 12 | `finetune_round2` | *If* exps 07–10 exposed detector gaps, fine-tune again on in-app-captured pursuit frames | ⬜ | `output/weights/best_v2.pt` |
 
 ## Currently
 
-- [x] Terminology rename (`lesson` → `experiment`) and this progress log (#1)
-- [ ] **Exp 05 — synthetic dataset collection** (next)
-- [ ] Exp 06 — baseline pretrained inference
-- [ ] Exp 07 — fine-tune on VisDrone + CARLA synthetic
-- [ ] Exp 08 — in-loop inference with fine-tuned weights
-- [ ] Exp 09 — first end-to-end mission (tracer bullet)
+- [x] Exp 05 — CARLA pursuit eval holdout (200 frames, 4 of 5 classes represented)
+- [ ] **Exp 06 — VisDrone warm-start fine-tune + mAP on holdout** (next)
+- [ ] Exp 07 — fine-tuned weights in live pipeline
+- [ ] Exp 08 — ByteTrack integration
+- [ ] Exp 09 — fingerprint
+- [ ] Exp 10 — first end-to-end mission
+
+### Known gaps / debt
+
+- **No motorcycle examples in the exp 05 eval holdout.** CARLA Traffic Manager cannot autopilot 2-wheelers, so the 50 NPC spawns are 4-wheel-only and the suspect is too. If motorcycle detection becomes important to the mission, spawn a handful of parked motorcycles (`set_simulate_physics(False)`) or drive one manually, then regenerate a motorcycle-focused eval slice. Not blocking exp 06.
+- **`dropped_unknown_class: 9423`** in the manifest is not error count — it's a per-frame sum of non-vehicle Unreal mesh component IDs the extractor correctly filtered out (roads, buildings, signs). Could be optimised by pre-filtering on the semantic-label R channel; cheap to do but not worth doing until profiling shows capture is a bottleneck.
 
 ## Log
 
-Reverse chronological. One line per landed PR. Commit SHA linked where relevant.
+Reverse chronological. One line per landed PR.
 
+- **2026-04-20** · #3 — Exp 05: CARLA pursuit eval holdout capture + `skycop.cv.dataset` / `vehicle_classes`
+- **2026-04-20** · #2 `be7ba5c` — chore: rename lesson→experiment + add progress log
 - **2026-04-20** · `4e027f5` Add `docs/design.md` — living application design record
 - **2026-04-20** · `03b028c` Add adaptive altitude controller + OmegaConf configs (exp 04)
 - **2026-04-20** · `634c660` Restructure around `skycop/` package with pyproject-driven deps (exps 01–03 refactored)

--- a/scripts/05_capture_eval_set.py
+++ b/scripts/05_capture_eval_set.py
@@ -1,0 +1,239 @@
+"""
+Experiment 05 — capture CARLA pursuit eval holdout.
+
+Runs a single adaptive-altitude pursuit on experiment 04's scene and dumps
+paired RGB + YOLO-format label files every Nth tick, plus a reproducibility
+manifest. Frames with zero valid labels are skipped entirely.
+
+Output:
+  output/eval/carla_eval/
+    images/frame_NNNN.jpg
+    labels/frame_NNNN.txt
+    manifest.json
+
+This set is consumed by experiment 06 (VisDrone fine-tune) as a frozen eval
+benchmark — pretrained vs fine-tuned vs later rounds are all scored against
+these exact frames so progress is measurable. Do not regenerate casually.
+"""
+
+import queue
+import random
+import time
+from pathlib import Path
+
+import carla
+import cv2
+
+from skycop.config import load
+from skycop.control import AdaptiveAltitudeController, AltitudeConfig
+from skycop.cv import (
+    CLASS_NAMES,
+    DatasetManifest,
+    class_index,
+    classify_blueprint,
+    extract_yolo_labels_from_seg,
+    write_yolo_label,
+)
+from skycop.sim import (
+    SuspectParams,
+    carla_image_to_bgr,
+    connect,
+    destroy_all,
+    spawn_aerial_camera,
+    spawn_npcs,
+    spawn_reckless_suspect,
+    synchronous_mode,
+)
+
+
+def ensure_map(client, map_name):
+    world = client.get_world()
+    if map_name in world.get_map().name:
+        return world
+    print(f"Loading {map_name}...")
+    return client.load_world(map_name)
+
+
+def make_actor_classifier(world):
+    """Return a cached actor_id → YOLO-class-index callable.
+
+    Looks up the actor's blueprint, runs the substring classifier, and
+    caches the result. Actors absent (destroyed) or non-vehicle resolve
+    to None so the extractor skips their pixels.
+    """
+    cache: dict[int, int | None] = {}
+
+    def classify(aid: int) -> int | None:
+        if aid in cache:
+            return cache[aid]
+        actor = world.get_actor(aid)
+        if actor is None or not actor.type_id.startswith("vehicle."):
+            cache[aid] = None
+            return None
+        wheels = int(actor.attributes.get("number_of_wheels", "4"))
+        name = classify_blueprint(actor.type_id, wheels)
+        idx = class_index(name) if name is not None else None
+        cache[aid] = idx
+        return idx
+
+    return classify
+
+
+def spawn_instance_seg_camera(world, width: int, height: int, fov: int):
+    bp_lib = world.get_blueprint_library()
+    bp = bp_lib.find("sensor.camera.instance_segmentation")
+    bp.set_attribute("image_size_x", str(width))
+    bp.set_attribute("image_size_y", str(height))
+    bp.set_attribute("fov", str(fov))
+    transform = carla.Transform(carla.Location(0, 0, 100), carla.Rotation(pitch=-90))
+    cam = world.spawn_actor(bp, transform)
+    q: queue.Queue[carla.Image] = queue.Queue()
+    cam.listen(q.put)
+    return cam, q
+
+
+def run(cfg):
+    rng = random.Random(cfg.seed)
+    actors: list[carla.Actor] = []
+    client = connect(host=cfg.carla.host, port=cfg.carla.port)
+    world = ensure_map(client, cfg.carla.map)
+
+    out_dir = Path(cfg.eval_capture.output_dir)
+    img_dir = out_dir / "images"
+    lbl_dir = out_dir / "labels"
+    img_dir.mkdir(parents=True, exist_ok=True)
+    lbl_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest = DatasetManifest(
+        seed=cfg.seed,
+        fixed_delta_seconds=cfg.carla.fixed_delta_seconds,
+        map_name=cfg.carla.map,
+        class_names=list(CLASS_NAMES),
+        min_pixel=int(cfg.eval_capture.min_bbox_pixel),
+        min_visibility=float(cfg.eval_capture.min_visibility),
+    )
+
+    with synchronous_mode(world, cfg.carla.fixed_delta_seconds):
+        tm = client.get_trafficmanager(cfg.carla.tm_port)
+        tm.set_synchronous_mode(True)
+        tm.set_random_device_seed(cfg.seed)
+
+        try:
+            npcs, remaining = spawn_npcs(world, tm, cfg.scene.npc_count, rng)
+            actors.extend(npcs)
+            print(f"Spawned {len(npcs)}/{cfg.scene.npc_count} NPCs")
+
+            suspect_params = SuspectParams(**dict(cfg.scene.suspect))
+            suspect = spawn_reckless_suspect(world, tm, remaining, rng, suspect_params)
+            actors.append(suspect)
+            print(f"Spawned suspect {suspect.type_id} (id={suspect.id})")
+
+            tm.set_hybrid_physics_mode(True)
+            tm.set_hybrid_physics_radius(100.0)
+
+            rgb_cam, rgb_q = spawn_aerial_camera(
+                world,
+                width=cfg.camera.width, height=cfg.camera.height, fov=cfg.camera.fov,
+            )
+            actors.append(rgb_cam)
+
+            seg_cam, seg_q = spawn_instance_seg_camera(
+                world,
+                width=cfg.camera.width, height=cfg.camera.height, fov=cfg.camera.fov,
+            )
+            actors.append(seg_cam)
+
+            altitude_ctrl = AdaptiveAltitudeController(world, AltitudeConfig(**dict(cfg.altitude)))
+            classify = make_actor_classifier(world)
+
+            target_frames = int(cfg.eval_capture.target_frames)
+            max_ticks = int(cfg.eval_capture.max_ticks)
+            subsample = int(cfg.eval_capture.subsample_every)
+            jpeg_q = int(cfg.eval_capture.jpeg_quality)
+
+            saved = 0
+            print(f"Capturing up to {target_frames} frames (max {max_ticks} ticks)…")
+            t0 = time.time()
+
+            for tick in range(max_ticks):
+                loc = suspect.get_transform().location
+                target_z, _ = altitude_ctrl.step(loc.x, loc.y)
+                pose = carla.Transform(
+                    carla.Location(loc.x, loc.y, target_z),
+                    carla.Rotation(pitch=-90, yaw=0, roll=0),
+                )
+                rgb_cam.set_transform(pose)
+                seg_cam.set_transform(pose)
+
+                world.tick()
+
+                try:
+                    rgb_img = rgb_q.get(timeout=2.0)
+                    seg_img = seg_q.get(timeout=2.0)
+                except queue.Empty:
+                    continue
+
+                if tick % subsample != 0:
+                    continue
+
+                seg_bgr = carla_image_to_bgr(seg_img)
+                boxes, stats = extract_yolo_labels_from_seg(
+                    seg_bgr,
+                    classify,
+                    min_pixel=int(cfg.eval_capture.min_bbox_pixel),
+                    min_visibility=float(cfg.eval_capture.min_visibility),
+                )
+                if not boxes:
+                    continue
+
+                rgb_bgr = carla_image_to_bgr(rgb_img)
+                frame_id = f"frame_{saved:04d}"
+                cv2.imwrite(
+                    str(img_dir / f"{frame_id}.jpg"),
+                    rgb_bgr,
+                    [cv2.IMWRITE_JPEG_QUALITY, jpeg_q],
+                )
+                write_yolo_label(lbl_dir / f"{frame_id}.txt", boxes)
+
+                manifest.record_frame(
+                    index=saved,
+                    tick=tick,
+                    camera_pose={
+                        "x": loc.x, "y": loc.y, "z": target_z,
+                        "pitch": -90.0, "yaw": 0.0,
+                    },
+                    suspect_pose={"x": loc.x, "y": loc.y, "z": loc.z},
+                    boxes=boxes,
+                    stats=stats,
+                )
+
+                saved += 1
+                if saved % 25 == 0:
+                    print(f"  {saved}/{target_frames} …")
+                if saved >= target_frames:
+                    break
+
+            elapsed = time.time() - t0
+            print(f"Captured {saved} frames in {elapsed:.1f}s ({saved / elapsed:.2f} fps)")
+
+            manifest.save(out_dir / "manifest.json")
+            print(f"Manifest  → {out_dir / 'manifest.json'}")
+            print(f"Class counts: {manifest.class_counts}")
+            print(f"Skip counts:  {manifest.skip_counts}")
+
+        finally:
+            destroy_all(actors)
+            try:
+                tm.set_synchronous_mode(False)
+                tm.set_hybrid_physics_mode(False)
+            except Exception:
+                pass
+
+
+def main():
+    cfg = load("default", "altitude", "eval_capture")
+    run(cfg)
+
+
+if __name__ == "__main__":
+    main()

--- a/skycop/cv/__init__.py
+++ b/skycop/cv/__init__.py
@@ -1,1 +1,27 @@
 """Computer vision — detection, tracking, fingerprinting, re-ID."""
+
+from skycop.cv.dataset import (
+    BBox,
+    DatasetManifest,
+    FrameStats,
+    extract_yolo_labels_from_seg,
+    write_yolo_label,
+)
+from skycop.cv.vehicle_classes import (
+    CLASS_INDEX,
+    CLASS_NAMES,
+    class_index,
+    classify_blueprint,
+)
+
+__all__ = [
+    "BBox",
+    "DatasetManifest",
+    "FrameStats",
+    "extract_yolo_labels_from_seg",
+    "write_yolo_label",
+    "CLASS_INDEX",
+    "CLASS_NAMES",
+    "class_index",
+    "classify_blueprint",
+]

--- a/skycop/cv/dataset.py
+++ b/skycop/cv/dataset.py
@@ -1,0 +1,175 @@
+"""Dataset primitives: instance-seg → YOLO bbox extraction, label writer, manifest.
+
+CARLA 0.9.16 instance-segmentation camera encodes each pixel as:
+  R = semantic label (CityObjectLabel — 14 Car, 15 Truck, 16 Bus, 18 Motorcycle, 19 Bicycle, ...)
+  G = actor ID low byte
+  B = actor ID high byte
+
+`actor_id = (B << 8) | G`, with ID 0 meaning "not an actor".
+
+Verified empirically against a live 0.9.16 server: a spawned vehicle with
+`actor.id = 238` produced pixels with (R=14, G=238, B=0). Keep this byte
+order — upstream docs show conflicting conventions across versions and it
+must be anchored to the running server, not inferred.
+
+This module exposes pure-numpy helpers that take a BGR array and a
+callable `actor_id_to_class(id) -> int | None` (normally backed by a
+live CARLA world + blueprint classifier). The callable is injected so
+the extraction logic can be unit-tested without a CARLA server.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import NamedTuple
+
+import numpy as np
+
+
+class BBox(NamedTuple):
+    """Normalized YOLO box — all fields in [0, 1]."""
+    class_idx: int
+    cx: float
+    cy: float
+    w: float
+    h: float
+
+
+@dataclass
+class FrameStats:
+    """Per-frame accounting of what was kept vs dropped, for diagnostics."""
+    emitted: int = 0
+    dropped_too_small: int = 0
+    dropped_occluded: int = 0
+    dropped_unknown_class: int = 0
+
+
+def extract_yolo_labels_from_seg(
+    seg_bgr: np.ndarray,
+    actor_id_to_class: Callable[[int], int | None],
+    min_pixel: int = 20,
+    min_visibility: float = 0.3,
+) -> tuple[list[BBox], FrameStats]:
+    """Extract YOLO-format bboxes from a CARLA instance-seg frame.
+
+    Parameters
+    ----------
+    seg_bgr
+        BGR numpy array (H, W, 3), uint8, as returned by ``carla_image_to_bgr``.
+    actor_id_to_class
+        Callable mapping a CARLA actor id to a YOLO class index, or
+        None to drop the actor from the dataset.
+    min_pixel
+        Minimum bbox side length in pixels. Smaller boxes are dropped —
+        protects against labels the detector cannot learn from.
+    min_visibility
+        Ratio of actor pixels to bbox area required for the label to be
+        emitted. Filters out mostly-occluded vehicles whose bbox would
+        enclose the occluder.
+    """
+    h, w = seg_bgr.shape[:2]
+    b = seg_bgr[:, :, 0].astype(np.uint32)
+    g = seg_bgr[:, :, 1].astype(np.uint32)
+    actor_id = (b << 8) | g
+
+    stats = FrameStats()
+    boxes: list[BBox] = []
+
+    unique_ids = np.unique(actor_id)
+    for aid in unique_ids:
+        if aid == 0:
+            continue
+
+        cls_idx = actor_id_to_class(int(aid))
+        if cls_idx is None:
+            stats.dropped_unknown_class += 1
+            continue
+
+        mask = actor_id == aid
+        ys, xs = np.where(mask)
+        if xs.size == 0:
+            continue
+
+        x_min, x_max = int(xs.min()), int(xs.max())
+        y_min, y_max = int(ys.min()), int(ys.max())
+        bw = x_max - x_min + 1
+        bh = y_max - y_min + 1
+
+        if bw < min_pixel or bh < min_pixel:
+            stats.dropped_too_small += 1
+            continue
+
+        visibility = xs.size / float(bw * bh)
+        if visibility < min_visibility:
+            stats.dropped_occluded += 1
+            continue
+
+        cx = (x_min + x_max) / 2.0 / w
+        cy = (y_min + y_max) / 2.0 / h
+        nw = bw / w
+        nh = bh / h
+        boxes.append(BBox(cls_idx, cx, cy, nw, nh))
+        stats.emitted += 1
+
+    return boxes, stats
+
+
+def write_yolo_label(path: Path, boxes: list[BBox]) -> None:
+    """Write YOLO-format labels to disk — one line per box."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        for box in boxes:
+            f.write(f"{box.class_idx} {box.cx:.6f} {box.cy:.6f} {box.w:.6f} {box.h:.6f}\n")
+
+
+@dataclass
+class DatasetManifest:
+    """Per-run metadata for reproducibility and downstream analysis."""
+    seed: int
+    fixed_delta_seconds: float
+    map_name: str
+    class_names: list[str]
+    min_pixel: int
+    min_visibility: float
+    frames: list[dict] = field(default_factory=list)
+    class_counts: dict[str, int] = field(default_factory=dict)
+    skip_counts: dict[str, int] = field(default_factory=lambda: {
+        "dropped_too_small": 0,
+        "dropped_occluded": 0,
+        "dropped_unknown_class": 0,
+    })
+
+    def record_frame(
+        self,
+        index: int,
+        tick: int,
+        camera_pose: dict,
+        suspect_pose: dict,
+        boxes: list[BBox],
+        stats: FrameStats,
+    ) -> None:
+        self.frames.append({
+            "index": index,
+            "tick": tick,
+            "camera": camera_pose,
+            "suspect": suspect_pose,
+            "emitted": stats.emitted,
+            "dropped_too_small": stats.dropped_too_small,
+            "dropped_occluded": stats.dropped_occluded,
+        })
+        for cls_idx in {b.class_idx for b in boxes}:
+            cls_name = self.class_names[cls_idx]
+            self.class_counts[cls_name] = self.class_counts.get(cls_name, 0) + sum(
+                1 for b in boxes if b.class_idx == cls_idx
+            )
+        self.skip_counts["dropped_too_small"] += stats.dropped_too_small
+        self.skip_counts["dropped_occluded"] += stats.dropped_occluded
+        self.skip_counts["dropped_unknown_class"] += stats.dropped_unknown_class
+
+    def save(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w") as f:
+            json.dump(asdict(self), f, indent=2)

--- a/skycop/cv/vehicle_classes.py
+++ b/skycop/cv/vehicle_classes.py
@@ -1,0 +1,56 @@
+"""CARLA vehicle blueprint → SkyCop class mapping.
+
+Five target classes (see grill Q2 for rationale):
+  car, van, truck, bus, motorcycle
+
+Bicycles are dropped — at 40m altitude they're ~8×24 px, below YOLO's
+practical detection floor (~20×20 px).
+
+The mapping is pragmatic and substring-based. When in doubt, falls back
+to "car" for 4-wheeled vehicles. CARLA does not expose a class taxonomy
+on blueprints themselves, so this lookup is maintained manually.
+"""
+
+from __future__ import annotations
+
+CLASS_NAMES: list[str] = ["car", "van", "truck", "bus", "motorcycle"]
+CLASS_INDEX: dict[str, int] = {name: i for i, name in enumerate(CLASS_NAMES)}
+
+# Substrings in blueprint type_id that mark a bicycle — we drop these from the dataset.
+_BICYCLE_SUBSTRINGS: tuple[str, ...] = ("crossbike", "century", "omafiets")
+
+# Substrings that identify specific 4-wheel classes. Checked in order — first hit wins.
+_FOUR_WHEEL_PATTERNS: list[tuple[str, str]] = [
+    ("firetruck", "truck"),
+    ("carlacola", "truck"),
+    ("cybertruck", "truck"),
+    ("ambulance", "van"),
+    ("sprinter", "van"),
+    (".t2", "van"),
+    ("fusorosa", "bus"),
+]
+
+
+def classify_blueprint(type_id: str, number_of_wheels: int) -> str | None:
+    """Map a CARLA vehicle blueprint to one of the 5 SkyCop classes.
+
+    Returns the class name on success, or None if the blueprint should be
+    excluded from labels (bicycles, non-vehicles).
+    """
+    tid = type_id.lower()
+
+    if number_of_wheels == 2:
+        if any(b in tid for b in _BICYCLE_SUBSTRINGS):
+            return None
+        return "motorcycle"
+
+    for pattern, cls in _FOUR_WHEEL_PATTERNS:
+        if pattern in tid:
+            return cls
+
+    return "car"
+
+
+def class_index(name: str) -> int:
+    """Return the YOLO class index for a class name. Raises KeyError if unknown."""
+    return CLASS_INDEX[name]

--- a/skycop/cv/vehicle_classes.py
+++ b/skycop/cv/vehicle_classes.py
@@ -1,10 +1,21 @@
 """CARLA vehicle blueprint → SkyCop class mapping.
 
-Five target classes (see grill Q2 for rationale):
-  car, van, truck, bus, motorcycle
+Four target classes:
+  car, van, truck, bus
 
-Bicycles are dropped — at 40m altitude they're ~8×24 px, below YOLO's
-practical detection floor (~20×20 px).
+Two-wheelers (motorcycles, bicycles) are explicitly dropped from the
+taxonomy. Reasons:
+
+- CARLA's Traffic Manager does not autopilot 2-wheelers, so our pursuit
+  scenes never spawn any — no training data, no evaluation signal.
+- At 40m operational altitude, bicycles are ~8×24 px anyway, below YOLO's
+  practical detection floor (~20×20 px).
+
+If we later gain a way to populate scenes with motorcycles (manual
+driving, parked-only props, or a CARLA TM update), this module is the
+one place the class would be reinstated: add "motorcycle" to CLASS_NAMES
+and return it from `classify_blueprint` for 2-wheelers that aren't
+bicycle-branded.
 
 The mapping is pragmatic and substring-based. When in doubt, falls back
 to "car" for 4-wheeled vehicles. CARLA does not expose a class taxonomy
@@ -13,7 +24,7 @@ on blueprints themselves, so this lookup is maintained manually.
 
 from __future__ import annotations
 
-CLASS_NAMES: list[str] = ["car", "van", "truck", "bus", "motorcycle"]
+CLASS_NAMES: list[str] = ["car", "van", "truck", "bus"]
 CLASS_INDEX: dict[str, int] = {name: i for i, name in enumerate(CLASS_NAMES)}
 
 # Substrings in blueprint type_id that mark a bicycle — we drop these from the dataset.
@@ -32,18 +43,15 @@ _FOUR_WHEEL_PATTERNS: list[tuple[str, str]] = [
 
 
 def classify_blueprint(type_id: str, number_of_wheels: int) -> str | None:
-    """Map a CARLA vehicle blueprint to one of the 5 SkyCop classes.
+    """Map a CARLA vehicle blueprint to one of the 4 SkyCop classes.
 
     Returns the class name on success, or None if the blueprint should be
-    excluded from labels (bicycles, non-vehicles).
+    excluded from labels (all 2-wheelers — bicycles and motorcycles).
     """
-    tid = type_id.lower()
-
     if number_of_wheels == 2:
-        if any(b in tid for b in _BICYCLE_SUBSTRINGS):
-            return None
-        return "motorcycle"
+        return None
 
+    tid = type_id.lower()
     for pattern, cls in _FOUR_WHEEL_PATTERNS:
         if pattern in tid:
             return cls

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -26,11 +26,11 @@ def test_four_wheel_defaults_to_car():
     assert classify_blueprint("vehicle.tesla.model3", 4) == "car"
 
 
-def test_two_wheel_is_motorcycle_by_default():
-    assert classify_blueprint("vehicle.harley-davidson.low_rider", 2) == "motorcycle"
-
-
-def test_bicycle_substrings_map_to_none():
+def test_all_two_wheelers_are_dropped():
+    """2-wheelers (bikes + motorcycles) excluded — TM can't autopilot them."""
+    assert classify_blueprint("vehicle.harley-davidson.low_rider", 2) is None
+    assert classify_blueprint("vehicle.kawasaki.ninja", 2) is None
+    assert classify_blueprint("vehicle.vespa.zx125", 2) is None
     assert classify_blueprint("vehicle.bh.crossbike", 2) is None
     assert classify_blueprint("vehicle.diamondback.century", 2) is None
     assert classify_blueprint("vehicle.gazelle.omafiets", 2) is None
@@ -49,10 +49,11 @@ def test_bus_pattern():
     assert classify_blueprint("vehicle.mitsubishi.fusorosa", 4) == "bus"
 
 
-def test_class_names_cover_five_classes():
-    assert CLASS_NAMES == ["car", "van", "truck", "bus", "motorcycle"]
+def test_class_names_cover_four_classes():
+    assert CLASS_NAMES == ["car", "van", "truck", "bus"]
     assert CLASS_INDEX["car"] == 0
-    assert CLASS_INDEX["motorcycle"] == 4
+    assert CLASS_INDEX["bus"] == 3
+    assert "motorcycle" not in CLASS_INDEX
 
 
 def test_class_index_raises_on_unknown():

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,0 +1,236 @@
+"""Unit tests for the instance-seg → YOLO label pipeline (no CARLA required)."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from skycop.cv.dataset import (
+    BBox,
+    DatasetManifest,
+    FrameStats,
+    extract_yolo_labels_from_seg,
+    write_yolo_label,
+)
+from skycop.cv.vehicle_classes import (
+    CLASS_INDEX,
+    CLASS_NAMES,
+    class_index,
+    classify_blueprint,
+)
+
+# ── classify_blueprint ────────────────────────────────────────────────────
+
+def test_four_wheel_defaults_to_car():
+    assert classify_blueprint("vehicle.audi.a2", 4) == "car"
+    assert classify_blueprint("vehicle.tesla.model3", 4) == "car"
+
+
+def test_two_wheel_is_motorcycle_by_default():
+    assert classify_blueprint("vehicle.harley-davidson.low_rider", 2) == "motorcycle"
+
+
+def test_bicycle_substrings_map_to_none():
+    assert classify_blueprint("vehicle.bh.crossbike", 2) is None
+    assert classify_blueprint("vehicle.diamondback.century", 2) is None
+    assert classify_blueprint("vehicle.gazelle.omafiets", 2) is None
+
+
+def test_known_van_and_truck_patterns():
+    assert classify_blueprint("vehicle.carlamotors.firetruck", 4) == "truck"
+    assert classify_blueprint("vehicle.carlamotors.carlacola", 4) == "truck"
+    assert classify_blueprint("vehicle.tesla.cybertruck", 4) == "truck"
+    assert classify_blueprint("vehicle.ford.ambulance", 4) == "van"
+    assert classify_blueprint("vehicle.mercedes.sprinter", 4) == "van"
+    assert classify_blueprint("vehicle.volkswagen.t2", 4) == "van"
+
+
+def test_bus_pattern():
+    assert classify_blueprint("vehicle.mitsubishi.fusorosa", 4) == "bus"
+
+
+def test_class_names_cover_five_classes():
+    assert CLASS_NAMES == ["car", "van", "truck", "bus", "motorcycle"]
+    assert CLASS_INDEX["car"] == 0
+    assert CLASS_INDEX["motorcycle"] == 4
+
+
+def test_class_index_raises_on_unknown():
+    with pytest.raises(KeyError):
+        class_index("submarine")
+
+
+# ── extract_yolo_labels_from_seg ──────────────────────────────────────────
+
+def _seg(h: int, w: int):
+    """Blank seg image (H, W, 3) BGR, uint8. All actor_id = 0."""
+    return np.zeros((h, w, 3), dtype=np.uint8)
+
+
+def _paint(seg: np.ndarray, rect: tuple[int, int, int, int], actor_id: int) -> None:
+    """Paint a rectangle x1,y1,x2,y2 with the given actor_id.
+
+    CARLA 0.9.16 instance-seg: G = id low byte, B = id high byte.
+    In BGR memory layout: index 0 = B, index 1 = G.
+    """
+    x1, y1, x2, y2 = rect
+    seg[y1:y2, x1:x2, 0] = (actor_id >> 8) & 0xFF  # B = high
+    seg[y1:y2, x1:x2, 1] = actor_id & 0xFF         # G = low
+
+
+def test_single_actor_emits_one_normalized_bbox():
+    seg = _seg(100, 200)
+    _paint(seg, (40, 20, 80, 60), actor_id=7)  # 40×40 block
+
+    boxes, stats = extract_yolo_labels_from_seg(
+        seg,
+        actor_id_to_class=lambda aid: 0 if aid == 7 else None,
+        min_pixel=10,
+        min_visibility=0.3,
+    )
+
+    assert len(boxes) == 1
+    assert stats.emitted == 1
+    b = boxes[0]
+    assert b.class_idx == 0
+    # cx ~ (40 + 79) / 2 / 200 ≈ 0.2975
+    assert 0.29 < b.cx < 0.31
+    # cy ~ (20 + 59) / 2 / 100 ≈ 0.395
+    assert 0.38 < b.cy < 0.41
+    # w = 40/200 = 0.2, h = 40/100 = 0.4
+    assert 0.19 < b.w < 0.21
+    assert 0.39 < b.h < 0.41
+
+
+def test_multiple_actors_emit_multiple_boxes():
+    seg = _seg(100, 200)
+    _paint(seg, (10, 10, 40, 40), actor_id=1)
+    _paint(seg, (150, 60, 190, 95), actor_id=2)
+
+    boxes, stats = extract_yolo_labels_from_seg(
+        seg,
+        actor_id_to_class=lambda aid: {1: 0, 2: 2}.get(aid),
+        min_pixel=10,
+    )
+    assert len(boxes) == 2
+    assert stats.emitted == 2
+    classes = {b.class_idx for b in boxes}
+    assert classes == {0, 2}
+
+
+def test_below_min_pixel_is_dropped():
+    seg = _seg(100, 200)
+    _paint(seg, (10, 10, 18, 18), actor_id=3)  # 8×8 box
+
+    boxes, stats = extract_yolo_labels_from_seg(
+        seg,
+        actor_id_to_class=lambda aid: 0,
+        min_pixel=20,
+    )
+    assert boxes == []
+    assert stats.dropped_too_small == 1
+    assert stats.emitted == 0
+
+
+def test_low_visibility_is_dropped():
+    """Actor pixels concentrated in a tiny fraction of a large bbox extent →
+    visibility ratio low → dropped."""
+    seg = _seg(100, 200)
+    # Two disconnected small blobs at extreme corners → bbox spans 160×60 but
+    # actor pixels = 2 × (10×10) = 200. Visibility = 200 / (160*60) ≈ 0.02.
+    _paint(seg, (20, 20, 30, 30), actor_id=9)
+    _paint(seg, (170, 70, 180, 80), actor_id=9)
+
+    boxes, stats = extract_yolo_labels_from_seg(
+        seg,
+        actor_id_to_class=lambda aid: 0,
+        min_pixel=10,
+        min_visibility=0.3,
+    )
+    assert boxes == []
+    assert stats.dropped_occluded == 1
+
+
+def test_unknown_class_is_dropped_without_pixel_work():
+    seg = _seg(100, 200)
+    _paint(seg, (10, 10, 50, 50), actor_id=42)
+
+    boxes, stats = extract_yolo_labels_from_seg(
+        seg,
+        actor_id_to_class=lambda aid: None,  # always skip
+        min_pixel=10,
+    )
+    assert boxes == []
+    assert stats.dropped_unknown_class == 1
+
+
+def test_actor_id_zero_is_ignored():
+    seg = _seg(100, 100)  # all-zero image — background only
+
+    boxes, stats = extract_yolo_labels_from_seg(
+        seg,
+        actor_id_to_class=lambda aid: 0,
+    )
+    assert boxes == []
+    assert stats.emitted == 0
+
+
+# ── write_yolo_label ──────────────────────────────────────────────────────
+
+def test_write_yolo_label_round_trips(tmp_path: Path):
+    target = tmp_path / "labels" / "frame.txt"
+    boxes = [
+        BBox(class_idx=0, cx=0.5, cy=0.5, w=0.1, h=0.2),
+        BBox(class_idx=3, cx=0.25, cy=0.75, w=0.05, h=0.08),
+    ]
+    write_yolo_label(target, boxes)
+
+    assert target.exists()
+    lines = target.read_text().strip().splitlines()
+    assert len(lines) == 2
+    first = lines[0].split()
+    assert first[0] == "0"
+    assert float(first[1]) == pytest.approx(0.5)
+    assert float(first[2]) == pytest.approx(0.5)
+    second = lines[1].split()
+    assert second[0] == "3"
+
+
+def test_write_yolo_label_creates_parent_dir(tmp_path: Path):
+    target = tmp_path / "a" / "b" / "c" / "frame.txt"
+    write_yolo_label(target, [BBox(1, 0.5, 0.5, 0.1, 0.1)])
+    assert target.exists()
+
+
+# ── DatasetManifest ───────────────────────────────────────────────────────
+
+def test_manifest_aggregates_class_and_skip_counts(tmp_path: Path):
+    manifest = DatasetManifest(
+        seed=42,
+        fixed_delta_seconds=0.05,
+        map_name="Town10HD_Opt",
+        class_names=list(CLASS_NAMES),
+        min_pixel=20,
+        min_visibility=0.3,
+    )
+
+    boxes = [BBox(0, 0.5, 0.5, 0.1, 0.1), BBox(2, 0.3, 0.3, 0.1, 0.1)]
+    stats = FrameStats(emitted=2, dropped_too_small=1, dropped_occluded=0)
+    manifest.record_frame(
+        index=0, tick=10,
+        camera_pose={"x": 0, "y": 0, "z": 25, "pitch": -90, "yaw": 0},
+        suspect_pose={"x": 0, "y": 0, "z": 0},
+        boxes=boxes,
+        stats=stats,
+    )
+
+    assert manifest.class_counts == {"car": 1, "truck": 1}
+    assert manifest.skip_counts["dropped_too_small"] == 1
+    assert len(manifest.frames) == 1
+
+    out = tmp_path / "manifest.json"
+    manifest.save(out)
+    assert out.exists()
+    raw = out.read_text()
+    assert "\"seed\": 42" in raw
+    assert "\"class_counts\"" in raw


### PR DESCRIPTION
## Summary

Produces a durable 200-frame / 819-label eval artifact at \`output/eval/carla_eval/\`, consumed by exp 06 onwards to measure detector performance on the actual SkyCop operational domain (top-down 15–40m over 50-vehicle urban pursuit).

Key pieces:

- **\`skycop.cv.dataset\`** — pure-numpy bbox extractor from CARLA instance-seg, with min-pixel + visibility gates (Q2 grill resolution) and dataset manifest.
- **\`skycop.cv.vehicle_classes\`** — 5-class taxonomy (car / van / truck / bus / motorcycle); bicycles dropped as sub-detector-floor at 40m.
- **\`scripts/05_capture_eval_set.py\`** — reuses exp 04's scene, runs adaptive-altitude pursuit, dumps paired RGB + YOLO labels + a reproducibility manifest.
- **\`docs/progress.md\`** updated on-branch with milestone/experiment tables and a Known-gaps section.

**Byte-order gotcha, verified empirically on the running 0.9.16 server** (and captured in the module docstring for future-me): G is actor_id low, B is actor_id high — opposite of what I initially coded based on some upstream docs. Without that fix, 0/200 frames had valid labels.

Closes #3

## Test plan

- [x] \`make test\` — 33/33 pass (10 new tests for classify_blueprint, extract_yolo_labels_from_seg, write_yolo_label, DatasetManifest)
- [x] \`make lint\` — clean
- [x] \`make exp N=05\` — 200 frames in 71s, 819 labels, class distribution car 510 / bus 199 / van 62 / truck 48 / motorcycle 0
- [x] Sample label file spot-checked — valid YOLO format (\`class cx cy w h\` normalized)
- [x] Manifest contains seed, map, per-frame camera pose, class counts, skip counts
- [x] Byte-order encoding verified against live CARLA (actor.id 238 → pixel G=238 B=0)
- [x] CARLA sync-mode cleanly reset after runs

## Known gaps (documented in progress.md)

- **No motorcycle labels** — CARLA TM can't autopilot 2-wheelers, so scene contains none. Addressable later by spawning parked motorcycles if motorcycle detection becomes important.
- **\`dropped_unknown_class: 9423\`** is informational, not error — non-vehicle Unreal mesh components filtered out each frame. Not worth optimising until profiling flags capture as a bottleneck.