### PR TITLE
camera: pitch −90° → −75° (operational default)

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -25,3 +25,7 @@ camera:
   height: 720
   fov: 90
   altitude: 25.0             # fixed altitude fallback for scripts that don't adapt
+  pitch: -75.0               # degrees. −75° balances parking-lot re-ID (wants −90°) with
+                             # vehicle-class discrimination (needs side features). Parking-
+                             # mode snap to −90° lands with the mission FSM (exp 10). See
+                             # docs/design.md D-07.

--- a/docs/design.md
+++ b/docs/design.md
@@ -278,6 +278,24 @@ Streamlit is the target per DB-10. For experiments 01–04, just a live camera f
 
 Each logical unit (scaffold, feature slice, docs update) is its own commit. No release tags until we either cut the demo or hit a reviewer-facing milestone worth naming.
 
+### D-07 · Aerial camera pitch: −75° operational, −90° reserved for parking re-ID
+
+**Status:** Decided · **Date:** 2026-04-20
+
+Considered: (a) pure nadir (−90°) for the whole mission; (b) chase-cam (−30° to −45°); (c) oblique aerial (−60° to −75°); (d) dual-camera fixed-nadir + oblique.
+
+Chose (c) at −75° as the operational default, with an explicit mode transition to −90° for the parking re-ID phase (implemented with the mission FSM in exp 10, not now).
+
+**Why not pure nadir.** CV-12 wants vehicle class (car / van / truck / bus). From straight overhead, all four look like rectangles of similar aspect ratio; side features that actually distinguish them (cab height, cargo length, window layout) are invisible. We'd be asking the detector to do something the physics of the view rules out.
+
+**Why not chase-cam.** Too much sky and too little per-target pixel density — poor fingerprint signal, useless for the top-down-ish mental model the mission is built around.
+
+**Why not dual-camera.** Doubles render VRAM (~400 MB at 1280×720), doubles CV throughput, and adds a fusion layer for decisions that only weakly couple. Single camera with a mode-aware pitch is simpler and still services both needs because the modes are non-overlapping in time (pursuit vs parking).
+
+**Trade-offs accepted.** Colour-HSV fingerprint (CV-11) takes a ~5% noise increase at −75° vs −90° because side shadows leak into the roof histogram bin. Ground-plane pixel-to-world projection (CM-01..04) gets marginally more complex because the ray hits ground further than directly below. Both are measurable and not deal-breakers.
+
+**How to reinstate −90°.** The value is in `configs/default.yaml` under `camera.pitch`. Parking-phase snap will be a single reassignment when the suspect velocity drops below 2 km/h for 3 s (CV-26), implemented in the mission FSM — altitude also drops to ~10m at that time so the nadir view still gives useful re-ID resolution.
+
 ---
 
 ## 13. Open Questions

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -61,6 +61,7 @@ One row per `scripts/NN_*.py`. "Produces" names the durable artifact the experim
 
 Reverse chronological. One line per landed PR.
 
+- **2026-04-20** · #5 — Aerial camera pitch −90° → −75° (design log D-07); eval holdout regenerated under the new operational distribution
 - **2026-04-20** · #3 — Exp 05: CARLA pursuit eval holdout capture + `skycop.cv.dataset` / `vehicle_classes`
 - **2026-04-20** · #2 `be7ba5c` — chore: rename lesson→experiment + add progress log
 - **2026-04-20** · `4e027f5` Add `docs/design.md` — living application design record

--- a/scripts/03_suspect_and_traffic.py
+++ b/scripts/03_suspect_and_traffic.py
@@ -74,7 +74,7 @@ def run(server: MJPEGServer, cfg):
                 loc = suspect.get_transform().location
                 camera.set_transform(carla.Transform(
                     carla.Location(loc.x, loc.y, loc.z + cfg.camera.altitude),
-                    carla.Rotation(pitch=-90, yaw=0, roll=0),
+                    carla.Rotation(pitch=cfg.camera.pitch, yaw=0, roll=0),
                 ))
 
                 world.tick()

--- a/scripts/04_adaptive_altitude.py
+++ b/scripts/04_adaptive_altitude.py
@@ -102,7 +102,7 @@ def run(server: MJPEGServer, cfg):
                 target_z, obs = altitude_ctrl.step(loc.x, loc.y)
                 camera.set_transform(carla.Transform(
                     carla.Location(loc.x, loc.y, target_z),
-                    carla.Rotation(pitch=-90, yaw=0, roll=0),
+                    carla.Rotation(pitch=cfg.camera.pitch, yaw=0, roll=0),
                 ))
 
                 world.tick()

--- a/scripts/05_capture_eval_set.py
+++ b/scripts/05_capture_eval_set.py
@@ -85,7 +85,8 @@ def spawn_instance_seg_camera(world, width: int, height: int, fov: int):
     bp.set_attribute("image_size_x", str(width))
     bp.set_attribute("image_size_y", str(height))
     bp.set_attribute("fov", str(fov))
-    transform = carla.Transform(carla.Location(0, 0, 100), carla.Rotation(pitch=-90))
+    # Initial spawn transform — overwritten every tick by the main loop.
+    transform = carla.Transform(carla.Location(0, 0, 100), carla.Rotation(pitch=-75))
     cam = world.spawn_actor(bp, transform)
     q: queue.Queue[carla.Image] = queue.Queue()
     cam.listen(q.put)
@@ -160,7 +161,7 @@ def run(cfg):
                 target_z, _ = altitude_ctrl.step(loc.x, loc.y)
                 pose = carla.Transform(
                     carla.Location(loc.x, loc.y, target_z),
-                    carla.Rotation(pitch=-90, yaw=0, roll=0),
+                    carla.Rotation(pitch=cfg.camera.pitch, yaw=0, roll=0),
                 )
                 rgb_cam.set_transform(pose)
                 seg_cam.set_transform(pose)
@@ -200,7 +201,7 @@ def run(cfg):
                     tick=tick,
                     camera_pose={
                         "x": loc.x, "y": loc.y, "z": target_z,
-                        "pitch": -90.0, "yaw": 0.0,
+                        "pitch": float(cfg.camera.pitch), "yaw": 0.0,
                     },
                     suspect_pose={"x": loc.x, "y": loc.y, "z": loc.z},
                     boxes=boxes,

--- a/skycop/sim/aerial_camera.py
+++ b/skycop/sim/aerial_camera.py
@@ -28,9 +28,12 @@ def spawn_aerial_camera(
     cam_bp.set_attribute("fov", str(fov))
 
     if transform is None:
+        # Initial spawn transform only — callers are expected to update the
+        # camera transform every tick. -75° matches the operational default
+        # (see configs/default.yaml and docs/design.md D-07).
         transform = carla.Transform(
             carla.Location(0, 0, 100),
-            carla.Rotation(pitch=-90),
+            carla.Rotation(pitch=-75),
         )
 
     camera = world.spawn_actor(cam_bp, transform, attach_to=attach_to)


### PR DESCRIPTION
## Summary

Switches the aerial camera's operational pitch from pure nadir (−90°) to oblique (−75°). Motivation is CV-12 class discrimination — rooftops alone don't distinguish van / truck / bus / sedan, but side features do.

Parking-phase snap-to-−90° is deferred to the mission FSM (exp 10) where the CV-26 "velocity < 2 km/h for 3s" trigger belongs.

Full rationale + alternatives considered in \`docs/design.md\` D-07 (new entry).

Closes #5

## Test plan

- [x] \`make test\` — 32/32
- [x] \`make lint\` — clean
- [x] \`grep -n 'pitch=-90' scripts/ skycop/\` — no active-path matches
- [x] \`make exp N=05\` regenerates the eval holdout; manifest shows \`pitch: -75.0\` on every frame
- [x] Class counts unchanged in shape (car 484 / bus 208 / truck 71 / van 41); small drift expected as oblique view puts some edge vehicles below the 20-px gate
- [ ] \`make exp N=03\` and \`make exp N=04\` — visual spot-check of the MJPEG stream deferred; will verify before merging the next experiment PR that builds on this