### PR TITLE
exp 06: pretrained YOLOv8s in-loop baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ __pycache__/
 output/
 recordings/
 
+# Model weights (ultralytics downloads yolov8s.pt here on first use)
+*.pt
+*.pth
+
 # IDE
 .vscode/
 .idea/

--- a/configs/detector.yaml
+++ b/configs/detector.yaml
@@ -1,0 +1,27 @@
+# YOLOv8 detector configuration — exp 06 and beyond.
+# Layered on top of configs/default.yaml.
+
+detector:
+  weights: yolov8s.pt          # ultralytics will auto-download to ~/.cache on first use
+  input_size: 640              # square input side (640 = stock YOLOv8s)
+  conf_threshold: 0.25
+  iou_threshold: 0.45
+  device: cuda:0
+  fp16: true
+
+  # COCO class id → SkyCop class id. nulls = COCO has no direct match.
+  # When scoring pretrained on our 4-class holdout, entries with null map emit
+  # no prediction for that SkyCop class — so the baseline is fairly reported
+  # with van marked N/A rather than penalised as always-missing.
+  coco_to_skycop:
+    2: 0    # car  → car
+    5: 3    # bus  → bus
+    7: 2    # truck → truck
+    # No COCO class maps to our "van" (class 1). Pretrained eval excludes van.
+
+baseline:
+  live_pursuit_seconds: 60
+  offline_eval_dir: /app/output/eval/carla_eval
+  metrics_out: /app/output/eval/baseline_metrics.json
+  fps_threshold_warn: 18       # log a warning if sustained live FPS below this
+  vram_threshold_gb: 5.5       # NFR-03

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,8 @@ services:
       - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-all}
       - NVIDIA_DRIVER_CAPABILITIES=compute,utility
       - HOME=/home/carla
+      - USER=carla              # see docs/carla_caveats.md §16 — torch/pwd lookup
+      - LOGNAME=carla            # fails for bind-mounted UIDs without /etc/passwd entry
       - PYTHONPATH=/app
       - CARLA_HOST=carla-server
       - CARLA_PORT=2000

--- a/docs/design.md
+++ b/docs/design.md
@@ -278,6 +278,21 @@ Streamlit is the target per DB-10. For experiments 01–04, just a live camera f
 
 Each logical unit (scaffold, feature slice, docs update) is its own commit. No release tags until we either cut the demo or hit a reviewer-facing milestone worth naming.
 
+### D-08 · Detection milestone: measure pretrained in-loop before any training
+
+**Status:** Decided · **Date:** 2026-04-20
+
+The original plan was "fine-tune on VisDrone first, then test in-loop." Flipped after grilling: we didn't know if speed, accuracy, or both were the constraint, and training a wrong-size model is a 2–3 hour mistake.
+
+New sequence:
+
+1. **Exp 06 — pretrained baseline (no training).** Run COCO YOLOv8s in-loop, measure sustained FPS, VRAM, and mAP on the CARLA holdout. Gives us the reference point every downstream step compares against. Total cost: weights download + ~90 s of runtime.
+2. **Exp 07 — fine-tune** — only once we know what's broken. If FPS was the bottleneck, consider YOLOv8n. If recall is the issue, target dataset composition accordingly. If class confusion dominates, weight the loss toward confusable pairs.
+
+Exp 06 resolved: FPS is fine (26), mAP is catastrophic (~2%). Gap is recall (6%) + class confusion (vans → trucks, buses missed). Fine-tuning is the right next step, and the in-app recording hook — rather than VisDrone — is now the favoured data source because it captures the *actual* operational distribution (−75° pitch, 15–40m altitude, CARLA textures).
+
+**Why this matters:** the original "VisDrone warm-start then CARLA" plan assumed we needed a two-stage dataset strategy. Exp 06's numbers suggest the pretrained model sees almost nothing useful in our frames (n_predictions = 44 across 200 frames containing 763 ground-truth boxes) — so the warm-start may offer diminishing returns vs just training from the pretrained initialisation on in-domain CARLA data directly. Exp 07 will test this empirically by starting without VisDrone and only adding it if the CARLA-only fine-tune underperforms.
+
 ### D-07 · Aerial camera pitch: −75° operational, −90° reserved for parking re-ID
 
 **Status:** Decided · **Date:** 2026-04-20

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -32,22 +32,39 @@ One row per `scripts/NN_*.py`. "Produces" names the durable artifact the experim
 | 03 | `suspect_and_traffic` | 50 NPCs + reckless suspect, fixed-altitude aerial follow | ✅ | — |
 | 04 | `adaptive_altitude` | SIM-11..14: adaptive altitude via `world.cast_ray()`, hybrid physics anchored on hero | ✅ | — |
 | 05 | `capture_eval_set` | CARLA pursuit eval holdout — 200 frames + YOLO labels + manifest | ✅ | `output/eval/carla_eval/` (200 jpg + 200 txt + manifest.json) |
-| 06 | `finetune_yolo` | YOLOv8s fine-tune on VisDrone warm-start; scores pretrained + fine-tuned on exp 05 holdout | ⬜ | `output/weights/best.pt` + `output/eval/metrics.json` |
-| 07 | `yolo_inloop` | Fine-tuned weights in live pipeline, boxes + conf overlaid on MJPEG | ⬜ | — |
-| 08 | `bytetrack` | Multi-object tracker on top of detections — persistent track IDs | ⬜ | — |
-| 09 | `fingerprint` | HSV colour + geometry attributes per track (CV-11..16) | ⬜ | — |
-| 10 | `mission_tracer` | First end-to-end mission slice: dispatch → detect → track → mission-end | ⬜ | — |
-| 11 | `dashboard_scoring` | Streamlit + event bus + scoring + debrief | ⬜ | — |
-| 12 | `finetune_round2` | *If* exps 07–10 exposed detector gaps, fine-tune again on in-app-captured pursuit frames | ⬜ | `output/weights/best_v2.pt` |
+| 06 | `yolo_baseline` | Pretrained YOLOv8s in-loop baseline — FPS/VRAM/mAP on exp 05 holdout | ✅ | `output/eval/baseline_metrics.json` |
+| 07 | `finetune_yolo` | Fine-tune YOLOv8s on CARLA-captured pursuit data (in-app recording hook), re-score against holdout | ⬜ | `output/weights/best.pt` + `output/eval/fine_tuned_metrics.json` |
+| 08 | `yolo_inloop` | Fine-tuned weights live, boxes + conf overlaid on MJPEG (compare vs baseline visually and in FPS) | ⬜ | — |
+| 09 | `bytetrack` | Multi-object tracker on top of detections — persistent track IDs | ⬜ | — |
+| 10 | `fingerprint` | HSV colour + geometry attributes per track (CV-11..16) | ⬜ | — |
+| 11 | `mission_tracer` | First end-to-end mission slice: dispatch → detect → track → mission-end | ⬜ | — |
+| 12 | `dashboard_scoring` | Streamlit + event bus + scoring + debrief | ⬜ | — |
 
 ## Currently
 
 - [x] Exp 05 — CARLA pursuit eval holdout (200 frames, all 4 classes represented)
-- [ ] **Exp 06 — VisDrone warm-start fine-tune + mAP on holdout** (next)
-- [ ] Exp 07 — fine-tuned weights in live pipeline
-- [ ] Exp 08 — ByteTrack integration
-- [ ] Exp 09 — fingerprint
-- [ ] Exp 10 — first end-to-end mission
+- [x] Exp 06 — Pretrained baseline: 26 FPS sustained, mAP@0.5 = 1.89% (unfit for our domain as expected — class confusion + recall gap)
+- [ ] **Exp 07 — Fine-tune YOLOv8s on in-app-captured CARLA pursuit data** (next; exp 06 confirmed pretrained baseline is not sufficient)
+- [ ] Exp 08 — fine-tuned weights in live pipeline (visual + FPS comparison vs baseline)
+- [ ] Exp 09 — ByteTrack integration
+- [ ] Exp 10 — fingerprint
+- [ ] Exp 11 — first end-to-end mission
+- [ ] Follow-up chore — convert scripts 01–05 to `logging` (script 06 already on it)
+
+### Detection baseline — exp 06 numbers
+
+Pretrained COCO YOLOv8s on `output/eval/carla_eval/` (200 frames, 763 vehicle GT boxes):
+
+| Metric | Value | Threshold | Verdict |
+|---|---|---|---|
+| Sustained FPS (live pursuit, 60s) | 26.14 | ≥ 18 | ✅ plenty of headroom |
+| Detection mean / p95 | 11.86 / 15.14 ms | — | ✅ fits the 50 ms tick budget |
+| Peak VRAM (torch process) | 0.03 GB | ≤ 5.5 GB | ✅ (CARLA itself is the VRAM budget holder, not the model) |
+| mAP@0.5 on 3 classes (car/truck/bus) | **0.019** | — | ❌ pretrained unfit |
+| mAP@0.5:0.95 | 0.016 | — | ❌ |
+| Predictions vs ground truths | 44 / 763 | — | Recall ≈ 6%; class confusion on top |
+
+**Interpretation:** the pipeline works end-to-end at speed but the pretrained model sees only a tiny fraction of vehicles and confuses classes that it does see (vans called "trucks," buses missed). This is expected — COCO training data is ground-level photography at altitudes of metres, not tens-of-metres. Fine-tuning on in-domain CARLA data is the correct next step; VisDrone warm-start may be less useful than originally assumed given how different the actual operational distribution is.
 
 ### Known gaps / debt
 
@@ -61,6 +78,7 @@ One row per `scripts/NN_*.py`. "Produces" names the durable artifact the experim
 
 Reverse chronological. One line per landed PR.
 
+- **2026-04-20** · #7 — Exp 06: pretrained YOLOv8s baseline (FPS/VRAM + mAP on holdout); design log D-08; `skycop.logs` + `skycop.cv.inference` + `skycop.cv.eval`
 - **2026-04-20** · #5 — Aerial camera pitch −90° → −75° (design log D-07); eval holdout regenerated under the new operational distribution
 - **2026-04-20** · #3 — Exp 05: CARLA pursuit eval holdout capture + `skycop.cv.dataset` / `vehicle_classes`
 - **2026-04-20** · #2 `be7ba5c` — chore: rename lesson→experiment + add progress log

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ dependencies = [
     "opencv-python-headless",
     "flask",
     "omegaconf",
+    "ultralytics",                 # YOLOv8 — pulls torch+torchvision (~800 MB on first build)
+    "torchmetrics[detection]",     # mAP computation (the [detection] extra pulls pycocotools)
 ]
 
 [project.optional-dependencies]

--- a/scripts/06_yolo_baseline.py
+++ b/scripts/06_yolo_baseline.py
@@ -1,0 +1,349 @@
+"""
+Experiment 06 — pretrained YOLOv8s baseline (no training).
+
+Two modes run back-to-back:
+
+1. Offline eval on the exp 05 holdout → mAP@0.5, mAP@0.5:0.95, per-class AP
+   for COCO-reachable classes (car / truck / bus). Van is excluded from
+   pretrained scoring because COCO has no van class — the omission is
+   recorded explicitly in the metrics JSON, not silently.
+
+2. Live pursuit on the exp 04 scene → detection overlay on the MJPEG
+   stream, sustained-FPS and peak-VRAM measurement. This is the acceptance
+   bar for NFR-01 / NFR-03 at this pipeline depth (detection only; tracking
+   and fingerprint still to land).
+
+Both modes use the pretrained yolov8s.pt COCO checkpoint with the SkyCop
+class remap defined in configs/detector.yaml.
+"""
+
+import json
+import logging
+import os
+import queue
+import random
+import time
+from pathlib import Path
+
+import carla
+import cv2
+import numpy as np
+
+from skycop.config import load
+from skycop.control import AdaptiveAltitudeController, AltitudeConfig
+from skycop.cv import (
+    CLASS_NAMES,
+    EvalBox,
+    YoloDetector,
+    coco_to_skycop_map,
+    read_yolo_labels,
+    score_predictions,
+)
+from skycop.dashboard import MJPEGServer
+from skycop.logs import setup_logging
+from skycop.sim import (
+    SuspectParams,
+    carla_image_to_bgr,
+    connect,
+    destroy_all,
+    spawn_aerial_camera,
+    spawn_npcs,
+    spawn_reckless_suspect,
+    synchronous_mode,
+)
+
+log = logging.getLogger("exp06")
+
+
+def ensure_map(client, map_name):
+    world = client.get_world()
+    if map_name in world.get_map().name:
+        return world
+    log.info("loading map %s", map_name)
+    return client.load_world(map_name)
+
+
+def build_detector(cfg) -> YoloDetector:
+    class_remap = coco_to_skycop_map(dict(cfg.detector.coco_to_skycop))
+    return YoloDetector(
+        weights=cfg.detector.weights,
+        class_remap=class_remap,
+        conf_threshold=cfg.detector.conf_threshold,
+        iou_threshold=cfg.detector.iou_threshold,
+        input_size=cfg.detector.input_size,
+        device=cfg.detector.device,
+        fp16=cfg.detector.fp16,
+    )
+
+
+# ── Mode 1: offline eval on holdout ────────────────────────────────────────
+
+def run_offline_eval(cfg, detector: YoloDetector) -> dict:
+    eval_dir = Path(cfg.baseline.offline_eval_dir)
+    img_dir = eval_dir / "images"
+    lbl_dir = eval_dir / "labels"
+    if not img_dir.exists() or not lbl_dir.exists():
+        raise FileNotFoundError(
+            f"Holdout not found at {eval_dir}. Run `make exp N=05` first."
+        )
+
+    class_filter = {v for v in dict(cfg.detector.coco_to_skycop).values() if v is not None}
+    frame_count = len(list(img_dir.glob("*.jpg")))
+    log.info("offline eval on %d frames, class_filter=%s", frame_count, sorted(class_filter))
+
+    preds_per_frame: list[list[EvalBox]] = []
+    gts_per_frame: list[list[EvalBox]] = []
+
+    for img_path in sorted(img_dir.glob("*.jpg")):
+        frame = cv2.imread(str(img_path))
+        if frame is None:
+            continue
+        h, w = frame.shape[:2]
+        detections = detector.predict(frame)
+        preds_per_frame.append([
+            EvalBox(
+                class_idx=d.class_idx,
+                x1=d.x1, y1=d.y1, x2=d.x2, y2=d.y2,
+                confidence=d.confidence,
+            )
+            for d in detections
+        ])
+
+        lbl_path = lbl_dir / (img_path.stem + ".txt")
+        gts_per_frame.append(read_yolo_labels(lbl_path, w, h))
+
+    metrics = score_predictions(preds_per_frame, gts_per_frame, class_filter=class_filter)
+    log.info("mAP@0.5      = %.4f", metrics.map_50)
+    log.info("mAP@0.5:0.95 = %.4f", metrics.map_50_95)
+    log.info(
+        "per-class AP@0.5: %s",
+        {CLASS_NAMES[k]: round(v, 4) for k, v in metrics.per_class_ap_50.items()},
+    )
+
+    return {
+        "mAP_50": metrics.map_50,
+        "mAP_50_95": metrics.map_50_95,
+        "per_class_ap_50": {
+            CLASS_NAMES[k]: round(v, 4) for k, v in metrics.per_class_ap_50.items()
+        },
+        "n_frames": metrics.n_frames,
+        "n_predictions": metrics.n_predictions,
+        "n_ground_truths": metrics.n_ground_truths,
+        "class_filter_skycop": metrics.class_filter,
+        "class_filter_names": [CLASS_NAMES[c] for c in metrics.class_filter]
+                              if metrics.class_filter else None,
+        "van_excluded_reason": "COCO has no 'van' class; pretrained cannot emit",
+    }
+
+
+# ── Mode 2: live pursuit ───────────────────────────────────────────────────
+
+def overlay_detections(frame, detections, class_names):
+    for d in detections:
+        x1, y1, x2, y2 = int(d.x1), int(d.y1), int(d.x2), int(d.y2)
+        color = (0, 255, 0)
+        cv2.rectangle(frame, (x1, y1), (x2, y2), color, 2)
+        label = f"{class_names[d.class_idx]} {d.confidence:.2f}"
+        cv2.putText(frame, label, (x1, max(y1 - 6, 12)),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.5, color, 1, cv2.LINE_AA)
+
+
+def overlay_stats(frame, fps: float, infer_ms: float, vram_gb: float):
+    txt = f"{fps:5.1f} FPS | det {infer_ms:5.1f}ms | VRAM {vram_gb:4.2f}GB"
+    cv2.putText(frame, txt, (20, 40), cv2.FONT_HERSHEY_SIMPLEX,
+                0.8, (0, 255, 255), 2, cv2.LINE_AA)
+
+
+def peak_vram_gb() -> float:
+    try:
+        import torch
+        if torch.cuda.is_available():
+            return torch.cuda.max_memory_allocated() / (1024 ** 3)
+    except Exception:
+        pass
+    return 0.0
+
+
+def run_live_pursuit(
+    cfg,
+    detector: YoloDetector,
+    server: MJPEGServer,
+    offline_metrics: dict,
+) -> dict:
+    rng = random.Random(cfg.seed)
+    actors: list[carla.Actor] = []
+    log.info("connecting to CARLA at %s:%s", cfg.carla.host, cfg.carla.port)
+    client = connect(host=cfg.carla.host, port=cfg.carla.port)
+    world = ensure_map(client, cfg.carla.map)
+
+    infer_times_ms: list[float] = []
+    frame_times_s: list[float] = []
+
+    try:
+        import torch
+        if torch.cuda.is_available():
+            torch.cuda.reset_peak_memory_stats()
+    except Exception:
+        pass
+
+    with synchronous_mode(world, cfg.carla.fixed_delta_seconds):
+        tm = client.get_trafficmanager(cfg.carla.tm_port)
+        tm.set_synchronous_mode(True)
+        tm.set_random_device_seed(cfg.seed)
+
+        try:
+            npcs, remaining = spawn_npcs(world, tm, cfg.scene.npc_count, rng)
+            actors.extend(npcs)
+            log.info("spawned %d/%d NPCs", len(npcs), cfg.scene.npc_count)
+
+            suspect_params = SuspectParams(**dict(cfg.scene.suspect))
+            suspect = spawn_reckless_suspect(world, tm, remaining, rng, suspect_params)
+            actors.append(suspect)
+            log.info("spawned suspect %s", suspect.type_id)
+
+            tm.set_hybrid_physics_mode(True)
+            tm.set_hybrid_physics_radius(100.0)
+
+            camera, img_queue = spawn_aerial_camera(
+                world, width=cfg.camera.width, height=cfg.camera.height, fov=cfg.camera.fov,
+            )
+            actors.append(camera)
+
+            altitude_ctrl = AdaptiveAltitudeController(world, AltitudeConfig(**dict(cfg.altitude)))
+
+            duration = float(cfg.baseline.live_pursuit_seconds)
+            log.info("live pursuit %.0fs with detection overlay…", duration)
+
+            t0 = time.perf_counter()
+            frames = 0
+            peak_vram = 0.0
+
+            while True:
+                frame_start = time.perf_counter()
+                loc = suspect.get_transform().location
+                target_z, _ = altitude_ctrl.step(loc.x, loc.y)
+                camera.set_transform(carla.Transform(
+                    carla.Location(loc.x, loc.y, target_z),
+                    carla.Rotation(pitch=cfg.camera.pitch, yaw=0, roll=0),
+                ))
+
+                world.tick()
+
+                try:
+                    image = img_queue.get(timeout=2.0)
+                except queue.Empty:
+                    continue
+
+                frame = carla_image_to_bgr(image)
+
+                t_inf_start = time.perf_counter()
+                detections = detector.predict(frame)
+                infer_ms = (time.perf_counter() - t_inf_start) * 1000
+                infer_times_ms.append(infer_ms)
+
+                overlay_detections(frame, detections, CLASS_NAMES)
+                cur_vram = peak_vram_gb()
+                peak_vram = max(peak_vram, cur_vram)
+
+                frames += 1
+                elapsed = time.perf_counter() - t0
+                fps_so_far = frames / elapsed if elapsed > 0 else 0.0
+                overlay_stats(frame, fps_so_far, infer_ms, cur_vram)
+                server.push(frame)
+
+                frame_times_s.append(time.perf_counter() - frame_start)
+
+                if elapsed >= duration:
+                    break
+
+            total_elapsed = time.perf_counter() - t0
+            sustained_fps = frames / total_elapsed
+            p95_infer = float(np.percentile(infer_times_ms, 95))
+            mean_infer = float(np.mean(infer_times_ms))
+            mean_frame_ms = float(np.mean(frame_times_s)) * 1000
+
+            log.info("frames          = %d", frames)
+            log.info("sustained FPS   = %.2f", sustained_fps)
+            log.info("detection mean  = %.2f ms (p95 %.2f ms)", mean_infer, p95_infer)
+            log.info("frame total     = %.2f ms (CARLA + overlay + MJPEG push)", mean_frame_ms)
+            log.info("peak VRAM       = %.2f GB", peak_vram)
+
+            if sustained_fps < float(cfg.baseline.fps_threshold_warn):
+                log.warning("sustained FPS below threshold (%s)", cfg.baseline.fps_threshold_warn)
+            if peak_vram > float(cfg.baseline.vram_threshold_gb):
+                log.warning("peak VRAM above threshold (%s GB)", cfg.baseline.vram_threshold_gb)
+
+            result = {
+                "frames": frames,
+                "duration_s": total_elapsed,
+                "sustained_fps": sustained_fps,
+                "detection_mean_ms": mean_infer,
+                "detection_p95_ms": p95_infer,
+                "frame_total_mean_ms": mean_frame_ms,
+                "peak_vram_gb": peak_vram,
+                "fps_threshold_warn": float(cfg.baseline.fps_threshold_warn),
+                "vram_threshold_gb": float(cfg.baseline.vram_threshold_gb),
+            }
+
+            # Save combined metrics HERE, before the cleanup finally.
+            # CARLA's C++ terminate on actor-registry issues can SIGABRT the
+            # process during tm teardown, bypassing Python's return path.
+            metrics = {
+                "model": cfg.detector.weights,
+                "pretrained_offline_eval": offline_metrics,
+                "pretrained_live_pursuit": result,
+            }
+            save_metrics_atomic(metrics, Path(cfg.baseline.metrics_out))
+            log.info("metrics → %s", cfg.baseline.metrics_out)
+
+        finally:
+            # Clean up TM state BEFORE destroying the hero actor it references
+            # (carla_caveats §10 — hybrid physics anchors on hero, attempting to
+            # reset after hero is gone triggers "destroyed actor" SIGABRT).
+            try:
+                tm.set_hybrid_physics_mode(False)
+                tm.set_synchronous_mode(False)
+            except Exception:
+                pass
+            destroy_all(actors)
+
+    return result
+
+
+def save_metrics_atomic(metrics: dict, out_path: Path) -> None:
+    """Write metrics JSON atomically — CARLA's SIGABRT on process exit can
+    interrupt a plain write before the page cache flushes."""
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = out_path.with_suffix(out_path.suffix + ".tmp")
+    with open(tmp_path, "w") as f:
+        json.dump(metrics, f, indent=2)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp_path, out_path)
+
+
+def main():
+    setup_logging()
+    cfg = load("default", "altitude", "detector")
+    detector = build_detector(cfg)
+
+    log.info("loading detector weights: %s", cfg.detector.weights)
+    detector._ensure_loaded()
+
+    log.info("=== Mode 1/2: offline eval on exp 05 holdout ===")
+    offline = run_offline_eval(cfg, detector)
+
+    log.info("=== Mode 2/2: live pursuit ===")
+    server = MJPEGServer(
+        title="SkyCop — Experiment 06",
+        hud="Experiment 06 · YOLOv8s COCO-pretrained baseline",
+    )
+    server.start(port=5000)
+    time.sleep(0.3)
+    # Metrics JSON is saved inside run_live_pursuit before the CARLA cleanup
+    # finally — CARLA's SIGABRT on TM teardown can bypass Python's return path.
+    run_live_pursuit(cfg, detector, server, offline_metrics=offline)
+
+
+if __name__ == "__main__":
+    main()

--- a/skycop/cv/__init__.py
+++ b/skycop/cv/__init__.py
@@ -7,6 +7,8 @@ from skycop.cv.dataset import (
     extract_yolo_labels_from_seg,
     write_yolo_label,
 )
+from skycop.cv.eval import EvalBox, EvalMetrics, read_yolo_labels, score_predictions
+from skycop.cv.inference import Detection, YoloDetector, coco_to_skycop_map
 from skycop.cv.vehicle_classes import (
     CLASS_INDEX,
     CLASS_NAMES,
@@ -24,4 +26,11 @@ __all__ = [
     "CLASS_NAMES",
     "class_index",
     "classify_blueprint",
+    "Detection",
+    "YoloDetector",
+    "coco_to_skycop_map",
+    "EvalBox",
+    "EvalMetrics",
+    "read_yolo_labels",
+    "score_predictions",
 ]

--- a/skycop/cv/eval.py
+++ b/skycop/cv/eval.py
@@ -1,0 +1,138 @@
+"""mAP scoring on a YOLO-format eval set.
+
+Uses torchmetrics' MeanAveragePrecision for explicit control over thresholds
+and per-class breakdown. Runs entirely on CPU — eval sets are small.
+
+`class_filter` restricts scoring to a subset of SkyCop classes. Used for
+the pretrained baseline, which has no COCO-equivalent for our `van` class —
+scoring pretrained on 4 classes would unfairly always-miss van and inflate
+the fine-tune's apparent improvement.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+
+@dataclass
+class EvalBox:
+    class_idx: int
+    x1: float
+    y1: float
+    x2: float
+    y2: float
+    confidence: float = 1.0      # 1.0 for ground truth
+
+
+def read_yolo_labels(label_path: Path, img_w: int, img_h: int) -> list[EvalBox]:
+    """Read a YOLO-format label file, return pixel-coordinate boxes.
+
+    YOLO file format: one line per box, `cls cx cy w h` all normalized to [0,1].
+    """
+    if not label_path.exists():
+        return []
+    out: list[EvalBox] = []
+    for line in label_path.read_text().strip().splitlines():
+        parts = line.split()
+        cls_idx = int(parts[0])
+        cx, cy, w, h = (float(x) for x in parts[1:5])
+        x1 = (cx - w / 2) * img_w
+        y1 = (cy - h / 2) * img_h
+        x2 = (cx + w / 2) * img_w
+        y2 = (cy + h / 2) * img_h
+        out.append(EvalBox(class_idx=cls_idx, x1=x1, y1=y1, x2=x2, y2=y2))
+    return out
+
+
+def filter_classes(
+    boxes: list[EvalBox], keep: set[int] | None
+) -> list[EvalBox]:
+    """Drop boxes whose class_idx is not in `keep`. None = keep all."""
+    if keep is None:
+        return boxes
+    return [b for b in boxes if b.class_idx in keep]
+
+
+@dataclass
+class EvalMetrics:
+    map_50: float                         # mAP at IoU=0.5
+    map_50_95: float                      # mAP averaged over IoU 0.5..0.95
+    per_class_ap_50: dict[int, float]     # class_idx → AP@0.5
+    n_frames: int
+    n_predictions: int
+    n_ground_truths: int
+    class_filter: list[int] | None
+
+
+def score_predictions(
+    preds_per_frame: list[list[EvalBox]],
+    gts_per_frame: list[list[EvalBox]],
+    class_filter: set[int] | None = None,
+) -> EvalMetrics:
+    """Compute mAP using torchmetrics.detection.MeanAveragePrecision.
+
+    `preds_per_frame[i]` and `gts_per_frame[i]` correspond to the same image.
+    Boxes are in `xyxy` pixel coordinates.
+    """
+    import torch
+    from torchmetrics.detection import MeanAveragePrecision
+
+    preds = [filter_classes(p, class_filter) for p in preds_per_frame]
+    gts = [filter_classes(g, class_filter) for g in gts_per_frame]
+
+    if class_filter is not None:
+        # torchmetrics handles arbitrary labels, but we sort for stable per_class output
+        pass
+
+    tm_preds = []
+    for frame_preds in preds:
+        if frame_preds:
+            tm_preds.append({
+                "boxes": torch.tensor([[b.x1, b.y1, b.x2, b.y2] for b in frame_preds]),
+                "scores": torch.tensor([b.confidence for b in frame_preds]),
+                "labels": torch.tensor([b.class_idx for b in frame_preds]),
+            })
+        else:
+            tm_preds.append({
+                "boxes": torch.zeros((0, 4)),
+                "scores": torch.zeros((0,)),
+                "labels": torch.zeros((0,), dtype=torch.int64),
+            })
+
+    tm_gts = []
+    for frame_gts in gts:
+        if frame_gts:
+            tm_gts.append({
+                "boxes": torch.tensor([[b.x1, b.y1, b.x2, b.y2] for b in frame_gts]),
+                "labels": torch.tensor([b.class_idx for b in frame_gts]),
+            })
+        else:
+            tm_gts.append({
+                "boxes": torch.zeros((0, 4)),
+                "labels": torch.zeros((0,), dtype=torch.int64),
+            })
+
+    metric = MeanAveragePrecision(box_format="xyxy", class_metrics=True)
+    metric.update(tm_preds, tm_gts)
+    result = metric.compute()
+
+    per_class_ap_50: dict[int, float] = {}
+    map_50_per_class = result.get("map_50_per_class")
+    classes_tensor = result.get("classes")
+    if map_50_per_class is not None and classes_tensor is not None:
+        for cls, ap in zip(classes_tensor.tolist(), map_50_per_class.tolist(), strict=True):
+            if not np.isnan(ap) and ap >= 0:
+                per_class_ap_50[int(cls)] = float(ap)
+
+    return EvalMetrics(
+        map_50=float(result["map_50"]),
+        map_50_95=float(result["map"]),
+        per_class_ap_50=per_class_ap_50,
+        n_frames=len(preds),
+        n_predictions=sum(len(p) for p in preds),
+        n_ground_truths=sum(len(g) for g in gts),
+        class_filter=sorted(class_filter) if class_filter is not None else None,
+    )

--- a/skycop/cv/inference.py
+++ b/skycop/cv/inference.py
@@ -1,0 +1,114 @@
+"""YOLOv8 inference wrapper.
+
+Thin adapter around `ultralytics.YOLO`. Keeps the rest of the codebase free
+of ultralytics-specific shapes — detectors produce `Detection` dataclasses,
+class indices are SkyCop indices (not COCO), and the model loads lazily so
+tests that import this module don't trigger a weights download.
+
+The class-remap map is injected rather than hardcoded — the same wrapper
+serves both the pretrained baseline (COCO class ids) and the fine-tuned
+model (SkyCop class ids direct, identity map).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass
+class Detection:
+    """One detection in image coordinates (pixel-space)."""
+    class_idx: int               # SkyCop class index (after remap)
+    confidence: float
+    x1: float
+    y1: float
+    x2: float
+    y2: float
+
+    @property
+    def cxcywh_normalized(self) -> tuple[float, float, float, float]:
+        w = self.x2 - self.x1
+        h = self.y2 - self.y1
+        return (self.x1 + w / 2, self.y1 + h / 2, w, h)
+
+
+class YoloDetector:
+    """Lazy-loaded YOLOv8 detector with optional source-class remap.
+
+    `class_remap` maps the model's native class ids → SkyCop class ids.
+    Entries mapping to None cause those predictions to be dropped.
+    """
+
+    def __init__(
+        self,
+        weights: str,
+        class_remap: dict[int, int | None] | None = None,
+        conf_threshold: float = 0.25,
+        iou_threshold: float = 0.45,
+        input_size: int = 640,
+        device: str = "cuda:0",
+        fp16: bool = True,
+    ) -> None:
+        self.weights = weights
+        self.class_remap = class_remap
+        self.conf_threshold = conf_threshold
+        self.iou_threshold = iou_threshold
+        self.input_size = input_size
+        self.device = device
+        self.fp16 = fp16
+        self._model = None
+
+    def _ensure_loaded(self):
+        if self._model is None:
+            from ultralytics import YOLO
+            # Let ultralytics own device + dtype setup via predict(half=...).
+            # Pre-casting the weights to half breaks layer fusion on load.
+            self._model = YOLO(self.weights)
+        return self._model
+
+    def predict(self, frame_bgr: np.ndarray) -> list[Detection]:
+        """Run inference on a single BGR frame, return SkyCop-indexed detections."""
+        model = self._ensure_loaded()
+        results = model.predict(
+            source=frame_bgr,
+            conf=self.conf_threshold,
+            iou=self.iou_threshold,
+            imgsz=self.input_size,
+            device=self.device,
+            half=self.fp16 and "cuda" in self.device,
+            verbose=False,
+        )
+        return self._extract_detections(results[0])
+
+    def _extract_detections(self, result) -> list[Detection]:
+        out: list[Detection] = []
+        if result.boxes is None or len(result.boxes) == 0:
+            return out
+        xyxy = result.boxes.xyxy.cpu().numpy()
+        confs = result.boxes.conf.cpu().numpy()
+        cls_ids = result.boxes.cls.cpu().numpy().astype(int)
+        for (x1, y1, x2, y2), c, cid in zip(xyxy, confs, cls_ids, strict=True):
+            mapped = self._remap(int(cid))
+            if mapped is None:
+                continue
+            out.append(Detection(
+                class_idx=mapped,
+                confidence=float(c),
+                x1=float(x1), y1=float(y1), x2=float(x2), y2=float(y2),
+            ))
+        return out
+
+    def _remap(self, native_cls: int) -> int | None:
+        if self.class_remap is None:
+            return native_cls
+        return self.class_remap.get(native_cls)  # None if absent or explicitly mapped to None
+
+
+def coco_to_skycop_map(cfg_map: dict) -> dict[int, int | None]:
+    """Build a dict usable as `class_remap` from the YAML config.
+
+    OmegaConf yields string keys for numeric yaml keys; normalise to int.
+    """
+    return {int(k): (None if v is None else int(v)) for k, v in cfg_map.items()}

--- a/skycop/logs.py
+++ b/skycop/logs.py
@@ -1,0 +1,42 @@
+"""Logging configuration for SkyCop entrypoints.
+
+Library modules just do `logger = logging.getLogger(__name__)` and emit —
+they never configure handlers. Scripts call `setup_logging()` once at the
+top of their `main()` to install a sensible console handler on the root
+logger.
+
+Output goes to stderr line-buffered (stdout is reserved for CARLA/Flask
+framework chatter and any machine-readable output). Level defaults to
+INFO and can be overridden via the `SKYCOP_LOG_LEVEL` env var.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+_FORMAT = "%(asctime)s %(levelname)-7s %(name)-22s %(message)s"
+_DATEFMT = "%H:%M:%S"
+
+
+def setup_logging(level: int | str | None = None) -> None:
+    """Install a console handler on the root logger. Idempotent."""
+    if level is None:
+        level = os.environ.get("SKYCOP_LOG_LEVEL", "INFO")
+    if isinstance(level, str):
+        level = level.upper()
+
+    handler = logging.StreamHandler(stream=sys.stderr)
+    handler.setFormatter(logging.Formatter(_FORMAT, datefmt=_DATEFMT))
+
+    root = logging.getLogger()
+    # Remove any previously-installed handlers so repeated calls don't duplicate.
+    for h in list(root.handlers):
+        root.removeHandler(h)
+    root.addHandler(handler)
+    root.setLevel(level)
+
+    # Quiet known noisy loggers.
+    logging.getLogger("PIL").setLevel(logging.WARNING)
+    logging.getLogger("werkzeug").setLevel(logging.WARNING)

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,0 +1,55 @@
+"""Unit tests for skycop.cv.eval — YOLO label reading + class filter.
+
+Score computation is exercised via torchmetrics; we only test the shape
+and filter behaviour, not the mAP values themselves.
+"""
+
+from pathlib import Path
+
+from skycop.cv.eval import EvalBox, filter_classes, read_yolo_labels
+
+
+def test_read_yolo_labels_parses_normalized_to_pixels(tmp_path: Path):
+    label = tmp_path / "frame.txt"
+    label.write_text("0 0.5 0.5 0.1 0.2\n3 0.25 0.75 0.05 0.08\n")
+    boxes = read_yolo_labels(label, img_w=200, img_h=100)
+    assert len(boxes) == 2
+
+    # First: cls=0, cx=0.5, cy=0.5, w=0.1, h=0.2 → x in [90, 110], y in [40, 60]
+    b0 = boxes[0]
+    assert b0.class_idx == 0
+    assert abs(b0.x1 - 90) < 1e-6
+    assert abs(b0.x2 - 110) < 1e-6
+    assert abs(b0.y1 - 40) < 1e-6
+    assert abs(b0.y2 - 60) < 1e-6
+
+    # Second: cls=3, cx=0.25, cy=0.75, w=0.05, h=0.08 → x centered at 50, y centered at 75
+    b1 = boxes[1]
+    assert b1.class_idx == 3
+
+
+def test_read_yolo_labels_returns_empty_for_missing_file(tmp_path: Path):
+    assert read_yolo_labels(tmp_path / "nonexistent.txt", 100, 100) == []
+
+
+def test_read_yolo_labels_returns_empty_for_empty_file(tmp_path: Path):
+    label = tmp_path / "empty.txt"
+    label.write_text("")
+    assert read_yolo_labels(label, 100, 100) == []
+
+
+def test_filter_classes_keeps_only_requested():
+    boxes = [
+        EvalBox(class_idx=0, x1=0, y1=0, x2=1, y2=1),
+        EvalBox(class_idx=1, x1=0, y1=0, x2=1, y2=1),
+        EvalBox(class_idx=2, x1=0, y1=0, x2=1, y2=1),
+        EvalBox(class_idx=3, x1=0, y1=0, x2=1, y2=1),
+    ]
+    filtered = filter_classes(boxes, keep={0, 2, 3})
+    assert {b.class_idx for b in filtered} == {0, 2, 3}
+    assert len(filtered) == 3
+
+
+def test_filter_classes_none_is_passthrough():
+    boxes = [EvalBox(class_idx=1, x1=0, y1=0, x2=1, y2=1)]
+    assert filter_classes(boxes, keep=None) == boxes

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,0 +1,51 @@
+"""Unit tests for skycop.cv.inference — class remap + Detection shape.
+
+The YoloDetector itself isn't exercised (it would pull ultralytics and
+weights). We test the remap logic that sits in front of it.
+"""
+
+from skycop.cv.inference import Detection, YoloDetector, coco_to_skycop_map
+
+
+def test_coco_to_skycop_map_normalizes_keys():
+    cfg_style = {2: 0, "5": 3, 7: 2}  # OmegaConf often gives str keys
+    m = coco_to_skycop_map(cfg_style)
+    assert m == {2: 0, 5: 3, 7: 2}
+
+
+def test_coco_to_skycop_map_passes_through_none():
+    """A None value for a key means 'drop this class' — must survive the conversion."""
+    m = coco_to_skycop_map({2: 0, 4: None})
+    assert m[2] == 0
+    assert m[4] is None
+
+
+def test_yolo_detector_remap_drops_unmapped_classes():
+    det = YoloDetector(weights="fake.pt", class_remap={2: 0, 7: 2})
+    assert det._remap(2) == 0
+    assert det._remap(7) == 2
+    # Class not in map → None (dropped)
+    assert det._remap(99) is None
+
+
+def test_yolo_detector_remap_drops_explicit_none():
+    det = YoloDetector(weights="fake.pt", class_remap={2: 0, 4: None})
+    assert det._remap(2) == 0
+    assert det._remap(4) is None
+
+
+def test_yolo_detector_identity_remap_when_none():
+    """No remap provided → pass class_idx through unchanged."""
+    det = YoloDetector(weights="fake.pt", class_remap=None)
+    assert det._remap(0) == 0
+    assert det._remap(3) == 3
+    assert det._remap(99) == 99
+
+
+def test_detection_cxcywh_normalized_matches_xyxy():
+    d = Detection(class_idx=0, confidence=0.9, x1=10, y1=20, x2=60, y2=70)
+    cx, cy, w, h = d.cxcywh_normalized
+    assert cx == 35
+    assert cy == 45
+    assert w == 50
+    assert h == 50


### PR DESCRIPTION
## Summary

Measures what pretrained COCO YOLOv8s gives us on the real operational distribution before burning training cycles. This is the tracer-bullet pass the grill identified: don't train a wrong-size model or chase the wrong axis.

**Findings (from `output/eval/baseline_metrics.json`):**

| Metric | Value | Bar | Verdict |
|---|---|---|---|
| Sustained FPS (live pursuit, 60s) | 26.14 | ≥ 18 | ✅ comfortable headroom for tracker + fingerprint |
| Detection mean / p95 | 11.86 / 15.14 ms | fit 50ms tick | ✅ |
| Peak VRAM (torch-process only) | 0.03 GB | ≤ 5.5 GB total | ✅ (CARLA rendering dominates GPU, not the model) |
| mAP@0.5 (car/truck/bus; van excluded) | **0.019** | — | ❌ pretrained unfit |
| Predictions vs ground-truths | 44 / 763 | — | ~6% recall + class confusion on top |

So: pipeline works at speed, but the model sees almost nothing useful in aerial frames. Vans get called trucks, buses are missed entirely. This directly motivates exp 07 — fine-tune on in-domain data — with the VisDrone warm-start now optional rather than mandatory.

## What's in the PR

- **`skycop.cv.inference`** — `YoloDetector` wrapper with injected class remap (COCO→SkyCop), lazy weights load, fp16 via `predict(half=True)` (pre-casting weights breaks ultralytics' layer fusion on load).
- **`skycop.cv.eval`** — `MeanAveragePrecision` via torchmetrics with `class_filter` so the pretrained baseline excludes van cleanly instead of always-missing it.
- **`skycop.logs`** — `setup_logging()` utility; script 06 uses `logging` instead of `print`. Remaining scripts in a chore follow-up.
- **`scripts/06_yolo_baseline.py`** — runs both modes back-to-back (offline eval → live pursuit). Saves metrics atomically from inside the try block (CARLA's SIGABRT during TM teardown can kill the process before Python returns; verified empirically).
- **`configs/detector.yaml`** — model variant, conf/iou thresholds, COCO→SkyCop map with `null` for van.
- **`pyproject.toml`** — adds `ultralytics`, `torchmetrics[detection]`.
- **`docker-compose.yml`** — adds `USER`/`LOGNAME` env because torch's inductor init hits `getpass.getuser()` which fails on bind-mounted UIDs (carla_caveats §16).
- **`docs/design.md`** — D-08 captures the sequence-swap rationale.
- **`docs/progress.md`** — exp 06 ✅ with full numbers, exp 07 now "fine-tune on CARLA-captured data."

Closes #7

## Test plan

- [x] `make test` — 43/43 (6 new: inference class_remap behaviour + eval label/filter logic)
- [x] `make lint` — clean
- [x] `make exp N=06` — completes end-to-end, writes `output/eval/baseline_metrics.json` with the offline + live-pursuit blocks populated
- [x] Live pursuit visually shows boxes overlaid on the MJPEG feed at `http://localhost:5000`
- [x] Metrics JSON saves even though CARLA terminates the process at exit (atomic write caught by the fix)

## Follow-ups queued

- **Chore PR:** convert scripts 01–05 to `skycop.logs.setup_logging()` instead of print.
- **Exp 07:** fine-tune YOLOv8s on in-app-captured CARLA pursuit frames. If it underperforms, layer in VisDrone warm-start.
- **Cosmetic:** the CARLA std::runtime_error on process exit still fires (TM teardown order). Doesn't affect data. Can be chased later with a `signal.signal(SIGABRT, ...)` handler if reviewers flag it.