### PR TITLE
cv: collapse detector to single-class 'vehicle' (fingerprint keeps 4-class)

### DIFF
--- a/configs/detector.yaml
+++ b/configs/detector.yaml
@@ -9,15 +9,14 @@ detector:
   device: cuda:0
   fp16: true
 
-  # COCO class id → SkyCop class id. nulls = COCO has no direct match.
-  # When scoring pretrained on our 4-class holdout, entries with null map emit
-  # no prediction for that SkyCop class — so the baseline is fairly reported
-  # with van marked N/A rather than penalised as always-missing.
+  # COCO class id → SkyCop detector class id. Our detector is single-class
+  # (index 0 = "vehicle") — see docs/design.md D-09. Every COCO vehicle
+  # class we accept collapses to 0.
   coco_to_skycop:
-    2: 0    # car  → car
-    5: 3    # bus  → bus
-    7: 2    # truck → truck
-    # No COCO class maps to our "van" (class 1). Pretrained eval excludes van.
+    2: 0    # car        → vehicle
+    5: 0    # bus        → vehicle
+    7: 0    # truck      → vehicle
+    # (COCO has no van class, so pretrained loses van coverage — expected.)
 
 baseline:
   live_pursuit_seconds: 60

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -141,7 +141,7 @@ The suspect is unaware of the drone. Its behaviour is driven by a scripted finit
 
 | ID | Requirement |
 |----|-------------|
-| CV-01 | System shall use YOLOv8m fine-tuned on VisDrone dataset and CARLA-generated synthetic data |
+| CV-01 | System shall use YOLOv8s (single-class `vehicle`; see design D-08 for size and D-09 for taxonomy) fine-tuned on CARLA-generated synthetic data. VisDrone warm-start optional — used only if the CARLA-only fine-tune underperforms against the eval holdout. |
 | CV-02 | Detection shall run at minimum 20 FPS on RTX 4050 using fp16 inference |
 | CV-03 | System shall achieve minimum 85% mAP@0.5 on aerial vehicle detection benchmark |
 | CV-04 | Training data shall be generated using CARLA's instance segmentation camera to produce pixel-accurate bounding box labels automatically — no manual annotation |
@@ -164,7 +164,7 @@ The system shall build and maintain a multi-attribute fingerprint of the suspect
 | ID | Attribute | Method |
 |----|-----------|--------|
 | CV-11 | Colour | HSV histogram on roof bounding box region |
-| CV-12 | Vehicle class | YOLOv8 classification (car / van / truck / motorcycle) |
+| CV-12 | Vehicle class | One of `{car, van, truck, bus}`; sourced from the dispatch description at mission start and from CARLA blueprint metadata at training-data-capture time. **Not** produced by the detector — the detector is single-class (see design D-09). The fingerprint compares the dispatch class against candidates' blueprint-derived class, with soft-score weighting rather than hard filtering. |
 | CV-13 | Roof shape | Bounding box aspect ratio + contour descriptor |
 | CV-14 | Apparent size | Normalised bounding box area relative to altitude |
 | CV-15 | Speed | Kalman filter velocity estimate from track positions |

--- a/docs/design.md
+++ b/docs/design.md
@@ -278,6 +278,24 @@ Streamlit is the target per DB-10. For experiments 01–04, just a live camera f
 
 Each logical unit (scaffold, feature slice, docs update) is its own commit. No release tags until we either cut the demo or hit a reviewer-facing milestone worth naming.
 
+### D-09 · Detector taxonomy: single class "vehicle"
+
+**Status:** Decided · **Date:** 2026-04-20
+
+The detector emits one class (`vehicle`). Fine-grained class (`car / van / truck / bus`) moves to the fingerprint module as an attribute sourced from CARLA blueprint metadata at training-data capture time.
+
+**Rationale.** Three independent arguments all point the same way.
+
+1. **CARLA structurally confounds fine-grained classes.** The Traffic Manager doesn't autopilot 2-wheelers (dropped earlier in D-07's predecessor). Bus class in Town10HD_Opt is backed by a single vehicle model (`vehicle.mitsubishi.fusorosa`) which we also always pick as suspect — so every bus instance in training data is the same make/model at similar framing. Fine-tuning learns "Fusorosa ≈ bus", not a general bus detector. The van class is ~3% of NPC spawns, the truck class ~5%, and cars ~75% — a 25:1 imbalance that biases any unweighted fine-tune.
+2. **Dispatch provides the suspect's class before CV runs.** FR-03 specifies the dispatch alert carries a vehicle description including class. The detector does not need to classify to fulfil the mission — it needs to localize, so the fingerprint can score candidates against a known description.
+3. **The detector's class output, if used as a hard filter, would remove the suspect.** If the fine-tuned detector's recall on van is (say) 70%, filtering by detector-class when dispatch says "van" drops 30% of real van vehicles — potentially including the suspect. The fingerprint's soft-scoring across colour + geometry + class is robust to this; hard class filtering is not.
+
+**How the fingerprint gets class.** At training-data capture (exp 05 onward), each extracted bbox already knows its CARLA actor id, so `skycop.cv.classify_blueprint()` supplies a `car / van / truck / bus` label into the per-frame manifest (free, from ground truth). At inference time in a CARLA-hosted demo, the same metadata is available via `world.get_actor(id)`. For a real-world deployment (out of scope) the class would come from bbox-geometry heuristics or a small secondary classifier — future work.
+
+**Trade-offs accepted.** (a) We no longer claim "detector knows what class each vehicle is"; (b) CV-03's 85% mAP target now applies to single-class localization, where it's easier; (c) requirements.md CV-01 and CV-12 were updated to reflect the reframe. The class attribute still exists and still feeds into the suspect-match score — just not through the detector.
+
+**Baseline numbers (exp 06 re-run at single-class).** Pretrained YOLOv8s on COCO: mAP@0.5 = 4.95% (up from 1.89% at 4-class, because class-confusion penalty is gone, but recall is still ~4.6% — pretrained genuinely does not recognise aerial vehicles). That's the number exp 07 aims to beat.
+
 ### D-08 · Detection milestone: measure pretrained in-loop before any training
 
 **Status:** Decided · **Date:** 2026-04-20

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -43,7 +43,7 @@ One row per `scripts/NN_*.py`. "Produces" names the durable artifact the experim
 ## Currently
 
 - [x] Exp 05 — CARLA pursuit eval holdout (200 frames, all 4 classes represented)
-- [x] Exp 06 — Pretrained baseline: 26 FPS sustained, mAP@0.5 = 1.89% (unfit for our domain as expected — class confusion + recall gap)
+- [x] Exp 06 — Pretrained baseline: 26 FPS sustained, mAP@0.5 = 4.95% single-class (pretrained does not recognise aerial vehicles — ~5% recall is the real problem, class confusion is now off the board per D-09)
 - [ ] **Exp 07 — Fine-tune YOLOv8s on in-app-captured CARLA pursuit data** (next; exp 06 confirmed pretrained baseline is not sufficient)
 - [ ] Exp 08 — fine-tuned weights in live pipeline (visual + FPS comparison vs baseline)
 - [ ] Exp 09 — ByteTrack integration
@@ -51,20 +51,20 @@ One row per `scripts/NN_*.py`. "Produces" names the durable artifact the experim
 - [ ] Exp 11 — first end-to-end mission
 - [ ] Follow-up chore — convert scripts 01–05 to `logging` (script 06 already on it)
 
-### Detection baseline — exp 06 numbers
+### Detection baseline — exp 06 numbers (single-class taxonomy)
 
-Pretrained COCO YOLOv8s on `output/eval/carla_eval/` (200 frames, 763 vehicle GT boxes):
+Re-run after the taxonomy collapse to single-class `vehicle` (design D-09). Pretrained COCO YOLOv8s on `output/eval/carla_eval/` (200 frames, 804 vehicle GT boxes):
 
 | Metric | Value | Threshold | Verdict |
 |---|---|---|---|
-| Sustained FPS (live pursuit, 60s) | 26.14 | ≥ 18 | ✅ plenty of headroom |
-| Detection mean / p95 | 11.86 / 15.14 ms | — | ✅ fits the 50 ms tick budget |
-| Peak VRAM (torch process) | 0.03 GB | ≤ 5.5 GB | ✅ (CARLA itself is the VRAM budget holder, not the model) |
-| mAP@0.5 on 3 classes (car/truck/bus) | **0.019** | — | ❌ pretrained unfit |
-| mAP@0.5:0.95 | 0.016 | — | ❌ |
-| Predictions vs ground truths | 44 / 763 | — | Recall ≈ 6%; class confusion on top |
+| Sustained FPS (live pursuit, 60s) | 25.63 | ≥ 18 | ✅ plenty of headroom |
+| Detection mean / p95 | 12.00 / 15.07 ms | — | ✅ fits the 50 ms tick budget |
+| Peak VRAM (torch process) | 0.03 GB | ≤ 5.5 GB | ✅ (CARLA itself dominates GPU, not the model) |
+| mAP@0.5 (single class `vehicle`) | **0.050** | — | ❌ pretrained unfit |
+| mAP@0.5:0.95 | 0.041 | — | ❌ |
+| Predictions vs ground truths | 37 / 804 | — | Recall ≈ 4.6% — pretrained genuinely does not recognise aerial vehicles |
 
-**Interpretation:** the pipeline works end-to-end at speed but the pretrained model sees only a tiny fraction of vehicles and confuses classes that it does see (vans called "trucks," buses missed). This is expected — COCO training data is ground-level photography at altitudes of metres, not tens-of-metres. Fine-tuning on in-domain CARLA data is the correct next step; VisDrone warm-start may be less useful than originally assumed given how different the actual operational distribution is.
+**Interpretation:** the pipeline works end-to-end at speed but the pretrained model sees only a tiny fraction of vehicles. The 4-class → 1-class collapse removed class-confusion as a confounding factor; the remaining 95% gap is pure recall. Exp 07 targets this directly via in-domain CARLA fine-tuning.
 
 ### Known gaps / debt
 
@@ -78,6 +78,7 @@ Pretrained COCO YOLOv8s on `output/eval/carla_eval/` (200 frames, 763 vehicle GT
 
 Reverse chronological. One line per landed PR.
 
+- **2026-04-20** · #9 — Detector taxonomy collapsed to single-class `vehicle`; fingerprint classes preserved for CV-12; eval holdout + baseline re-run under new taxonomy; design log D-09
 - **2026-04-20** · #7 — Exp 06: pretrained YOLOv8s baseline (FPS/VRAM + mAP on holdout); design log D-08; `skycop.logs` + `skycop.cv.inference` + `skycop.cv.eval`
 - **2026-04-20** · #5 — Aerial camera pitch −90° → −75° (design log D-07); eval holdout regenerated under the new operational distribution
 - **2026-04-20** · #3 — Exp 05: CARLA pursuit eval holdout capture + `skycop.cv.dataset` / `vehicle_classes`

--- a/scripts/05_capture_eval_set.py
+++ b/scripts/05_capture_eval_set.py
@@ -29,8 +29,7 @@ from skycop.control import AdaptiveAltitudeController, AltitudeConfig
 from skycop.cv import (
     CLASS_NAMES,
     DatasetManifest,
-    class_index,
-    classify_blueprint,
+    detector_class_for,
     extract_yolo_labels_from_seg,
     write_yolo_label,
 )
@@ -55,11 +54,12 @@ def ensure_map(client, map_name):
 
 
 def make_actor_classifier(world):
-    """Return a cached actor_id → YOLO-class-index callable.
+    """Return a cached actor_id → detector-class-index callable.
 
-    Looks up the actor's blueprint, runs the substring classifier, and
-    caches the result. Actors absent (destroyed) or non-vehicle resolve
-    to None so the extractor skips their pixels.
+    Every detected vehicle maps to the single detector class (index 0).
+    The fine-grained fingerprint class (car/van/truck/bus) is still
+    available via ``classify_blueprint`` and will be recorded into the
+    manifest at fingerprint integration time, not here.
     """
     cache: dict[int, int | None] = {}
 
@@ -71,8 +71,7 @@ def make_actor_classifier(world):
             cache[aid] = None
             return None
         wheels = int(actor.attributes.get("number_of_wheels", "4"))
-        name = classify_blueprint(actor.type_id, wheels)
-        idx = class_index(name) if name is not None else None
+        idx = detector_class_for(actor.type_id, wheels)
         cache[aid] = idx
         return idx
 

--- a/skycop/cv/__init__.py
+++ b/skycop/cv/__init__.py
@@ -12,8 +12,11 @@ from skycop.cv.inference import Detection, YoloDetector, coco_to_skycop_map
 from skycop.cv.vehicle_classes import (
     CLASS_INDEX,
     CLASS_NAMES,
+    FINGERPRINT_CLASSES,
+    FINGERPRINT_INDEX,
     class_index,
     classify_blueprint,
+    detector_class_for,
 )
 
 __all__ = [
@@ -24,8 +27,11 @@ __all__ = [
     "write_yolo_label",
     "CLASS_INDEX",
     "CLASS_NAMES",
+    "FINGERPRINT_CLASSES",
+    "FINGERPRINT_INDEX",
     "class_index",
     "classify_blueprint",
+    "detector_class_for",
     "Detection",
     "YoloDetector",
     "coco_to_skycop_map",

--- a/skycop/cv/vehicle_classes.py
+++ b/skycop/cv/vehicle_classes.py
@@ -1,36 +1,43 @@
 """CARLA vehicle blueprint → SkyCop class mapping.
 
-Four target classes:
-  car, van, truck, bus
+Two taxonomies live here, serving different layers of the pipeline:
 
-Two-wheelers (motorcycles, bicycles) are explicitly dropped from the
-taxonomy. Reasons:
+**Detector taxonomy** — a single class, ``vehicle``. Used for YOLOv8 training
+and inference. Rationale in ``docs/design.md`` D-09: dispatch already supplies
+the suspect's class to the mission; the detector's job is localization, not
+classification. Fine-grained classification from 15–40m aerial at −75° pitch
+is unreliable (structural imbalance + single-model-per-rare-class confound in
+CARLA) and adds noise without informational value for the mission.
 
-- CARLA's Traffic Manager does not autopilot 2-wheelers, so our pursuit
-  scenes never spawn any — no training data, no evaluation signal.
-- At 40m operational altitude, bicycles are ~8×24 px anyway, below YOLO's
-  practical detection floor (~20×20 px).
+**Fingerprint taxonomy** — ``car / van / truck / bus``, preserved for the
+CV-11..16 fingerprint module. Sourced from CARLA blueprint metadata at
+data-collection time (simulation-only shortcut) or from bbox geometry at
+inference time (future work), not from the detector's output.
 
-If we later gain a way to populate scenes with motorcycles (manual
-driving, parked-only props, or a CARLA TM update), this module is the
-one place the class would be reinstated: add "motorcycle" to CLASS_NAMES
-and return it from `classify_blueprint` for 2-wheelers that aren't
-bicycle-branded.
-
-The mapping is pragmatic and substring-based. When in doubt, falls back
-to "car" for 4-wheeled vehicles. CARLA does not expose a class taxonomy
-on blueprints themselves, so this lookup is maintained manually.
+Two-wheelers (motorcycles + bicycles) are excluded from both taxonomies:
+CARLA's Traffic Manager cannot autopilot them, so the training distribution
+contains none, and at 40m altitude bicycles would be below YOLO's practical
+detection floor.
 """
 
 from __future__ import annotations
 
-CLASS_NAMES: list[str] = ["car", "van", "truck", "bus"]
+# ── Detector taxonomy ─────────────────────────────────────────────────────
+
+CLASS_NAMES: list[str] = ["vehicle"]
 CLASS_INDEX: dict[str, int] = {name: i for i, name in enumerate(CLASS_NAMES)}
+
+# ── Fingerprint taxonomy (attribute for CV-11..16, NOT detector output) ──
+
+FINGERPRINT_CLASSES: list[str] = ["car", "van", "truck", "bus"]
+FINGERPRINT_INDEX: dict[str, int] = {name: i for i, name in enumerate(FINGERPRINT_CLASSES)}
+
 
 # Substrings in blueprint type_id that mark a bicycle — we drop these from the dataset.
 _BICYCLE_SUBSTRINGS: tuple[str, ...] = ("crossbike", "century", "omafiets")
 
-# Substrings that identify specific 4-wheel classes. Checked in order — first hit wins.
+# Substrings that identify specific 4-wheel categories — used only by the
+# fingerprint taxonomy. Checked in order — first hit wins.
 _FOUR_WHEEL_PATTERNS: list[tuple[str, str]] = [
     ("firetruck", "truck"),
     ("carlacola", "truck"),
@@ -43,10 +50,13 @@ _FOUR_WHEEL_PATTERNS: list[tuple[str, str]] = [
 
 
 def classify_blueprint(type_id: str, number_of_wheels: int) -> str | None:
-    """Map a CARLA vehicle blueprint to one of the 4 SkyCop classes.
+    """Return fine-grained fingerprint class for a CARLA vehicle blueprint.
 
-    Returns the class name on success, or None if the blueprint should be
-    excluded from labels (all 2-wheelers — bicycles and motorcycles).
+    Returns one of ``FINGERPRINT_CLASSES`` on success, or ``None`` if the
+    blueprint is excluded from the pipeline entirely (all 2-wheelers).
+
+    **Not** used by the detector — it's for the fingerprint module. The
+    detector uses ``detector_class_for`` instead.
     """
     if number_of_wheels == 2:
         return None
@@ -59,6 +69,19 @@ def classify_blueprint(type_id: str, number_of_wheels: int) -> str | None:
     return "car"
 
 
+def detector_class_for(type_id: str, number_of_wheels: int) -> int | None:
+    """Return the SkyCop detector class index for a CARLA vehicle blueprint.
+
+    All vehicles the detector cares about collapse to a single class (index 0,
+    ``vehicle``). 2-wheelers return ``None`` so they're dropped at label-
+    extraction time.
+    """
+    if number_of_wheels == 2:
+        return None
+    # Any other vehicle is a detection target.
+    return CLASS_INDEX["vehicle"]
+
+
 def class_index(name: str) -> int:
-    """Return the YOLO class index for a class name. Raises KeyError if unknown."""
+    """Return the detector class index for a class name. Raises KeyError if unknown."""
     return CLASS_INDEX[name]

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -15,8 +15,11 @@ from skycop.cv.dataset import (
 from skycop.cv.vehicle_classes import (
     CLASS_INDEX,
     CLASS_NAMES,
+    FINGERPRINT_CLASSES,
+    FINGERPRINT_INDEX,
     class_index,
     classify_blueprint,
+    detector_class_for,
 )
 
 # ── classify_blueprint ────────────────────────────────────────────────────
@@ -49,11 +52,27 @@ def test_bus_pattern():
     assert classify_blueprint("vehicle.mitsubishi.fusorosa", 4) == "bus"
 
 
-def test_class_names_cover_four_classes():
-    assert CLASS_NAMES == ["car", "van", "truck", "bus"]
-    assert CLASS_INDEX["car"] == 0
-    assert CLASS_INDEX["bus"] == 3
-    assert "motorcycle" not in CLASS_INDEX
+def test_detector_taxonomy_is_single_class():
+    assert CLASS_NAMES == ["vehicle"]
+    assert CLASS_INDEX["vehicle"] == 0
+    assert "car" not in CLASS_INDEX  # fingerprint-only, not a detector class
+
+
+def test_fingerprint_taxonomy_still_has_four_classes():
+    assert FINGERPRINT_CLASSES == ["car", "van", "truck", "bus"]
+    assert FINGERPRINT_INDEX["car"] == 0
+    assert FINGERPRINT_INDEX["bus"] == 3
+
+
+def test_detector_class_for_returns_zero_for_four_wheelers():
+    assert detector_class_for("vehicle.tesla.model3", 4) == 0
+    assert detector_class_for("vehicle.mitsubishi.fusorosa", 4) == 0
+    assert detector_class_for("vehicle.carlamotors.firetruck", 4) == 0
+
+
+def test_detector_class_for_drops_two_wheelers():
+    assert detector_class_for("vehicle.harley-davidson.low_rider", 2) is None
+    assert detector_class_for("vehicle.bh.crossbike", 2) is None
 
 
 def test_class_index_raises_on_unknown():
@@ -215,7 +234,7 @@ def test_manifest_aggregates_class_and_skip_counts(tmp_path: Path):
         min_visibility=0.3,
     )
 
-    boxes = [BBox(0, 0.5, 0.5, 0.1, 0.1), BBox(2, 0.3, 0.3, 0.1, 0.1)]
+    boxes = [BBox(0, 0.5, 0.5, 0.1, 0.1), BBox(0, 0.3, 0.3, 0.1, 0.1)]
     stats = FrameStats(emitted=2, dropped_too_small=1, dropped_occluded=0)
     manifest.record_frame(
         index=0, tick=10,
@@ -225,7 +244,7 @@ def test_manifest_aggregates_class_and_skip_counts(tmp_path: Path):
         stats=stats,
     )
 
-    assert manifest.class_counts == {"car": 1, "truck": 1}
+    assert manifest.class_counts == {"vehicle": 2}
     assert manifest.skip_counts["dropped_too_small"] == 1
     assert len(manifest.frames) == 1
 


### PR DESCRIPTION
## Summary

Moves the detector to a single-class taxonomy (`vehicle`) and parks the fine-grained `car/van/truck/bus` list on the fingerprint module as `FINGERPRINT_CLASSES`. Motivated by two independent problems and the mission's own design.

**Problem 1 — CARLA structurally confounds fine-grained aerial classes:**
- TM won't autopilot 2-wheelers (already dropped).
- Bus class in Town10HD_Opt is backed by a single vehicle model (`vehicle.mitsubishi.fusorosa`) always chosen as suspect → training data teaches \"Fusorosa-shape in centre = bus,\" not a real bus detector.
- Spawn imbalance gives ~25:1 car/van, ~12:1 car/truck, ~8:1 car/bus — any unweighted fine-tune inherits this bias.

**Problem 2 — detector class is redundant for the mission:**
- FR-03's dispatch alert already carries vehicle class. CV needs to localize, not classify.
- Using detector class as a hard filter risks dropping the suspect when recall on its true class is imperfect — worst failure mode possible.
- The fingerprint already does soft multi-attribute matching (colour, aspect ratio, size, heading, speed). Class can ride along as one soft-weighted component, sourced from CARLA blueprint metadata at collection time.

## What changed

- **Code:** `skycop.cv.vehicle_classes` splits into two taxonomies: detector (`CLASS_NAMES = [\"vehicle\"]`, `detector_class_for()`) and fingerprint (`FINGERPRINT_CLASSES` = 4 classes, `classify_blueprint()` preserved). Script 05 uses the detector helper.
- **Config:** `configs/detector.yaml` COCO→SkyCop remap now collapses car/truck/bus → 0.
- **Tests:** 4 updated / 2 new — detector taxonomy, fingerprint taxonomy preservation, `detector_class_for` for 4-wheelers / None for 2-wheelers.
- **Docs:** REQUIREMENTS.md CV-01 + CV-12 reframed; design.md gains D-09 with full reasoning; progress.md baseline table + log updated.
- **Artifacts (regenerated, not committed):** eval holdout at single-class, baseline metrics re-run.

## New baseline numbers (exp 06 re-run under single-class)

| Metric | Old (4-class) | New (1-class) |
|---|---|---|
| mAP@0.5 | 0.019 | **0.050** (class-confusion penalty gone, recall still ~4.6%) |
| mAP@0.5:0.95 | 0.016 | 0.041 |
| Sustained FPS | 26.1 | 25.6 |
| Detection mean/p95 | 11.9 / 15.1 ms | 12.0 / 15.1 ms |
| Predictions/GT | 44 / 763 | 37 / 804 |

The 2.6× bump in mAP@0.5 confirms class confusion was masking part of the pretrained model's actual localization ability. The remaining 95% gap is *pure recall* — pretrained COCO YOLOv8s simply does not recognise most aerial vehicles. Clean baseline for exp 07 to measure against.

Closes #9

## Test plan

- [x] `make test` — 46/46
- [x] `make lint` — clean
- [x] `make exp N=05` regenerates holdout with 804 class-0 labels (all `vehicle`)
- [x] `make exp N=06` re-runs baseline, writes new `output/eval/baseline_metrics.json`
- [x] `awk '{print $1}' output/eval/carla_eval/labels/*.txt | sort -u` → only `0`

## Next

Exp 07 — fine-tune YOLOv8s on CARLA-captured single-class data. Target: mAP@0.5 ≥ 0.85 on the regenerated holdout (CV-03). Grill + issue to follow.