### PR TITLE
exp 07: collect CARLA pursuit training dataset (5000 frames)

### DIFF
--- a/configs/training_dataset.yaml
+++ b/configs/training_dataset.yaml
@@ -1,0 +1,29 @@
+# Training-dataset collection — exp 07.
+# Layered on top of configs/default.yaml + configs/altitude.yaml.
+
+training_dataset:
+  output_dir: /app/output/dataset/carla_pursuit
+  target_frames_per_run: 500
+  subsample_every: 10          # 20 FPS / 10 = 2 Hz sampling
+  max_ticks_per_run: 6000      # ~5 min at 20 FPS
+  min_bbox_pixel: 20
+  min_visibility: 0.3
+  jpeg_quality: 92
+
+  # 10 runs across 3 weather presets (SIM-06). Seeds 100–109 — disjoint from
+  # exp 05's seed=42 so the eval holdout remains independent.
+  runs:
+    - {seed: 100, weather: ClearNoon}
+    - {seed: 101, weather: ClearNoon}
+    - {seed: 102, weather: ClearNoon}
+    - {seed: 103, weather: ClearNoon}
+    - {seed: 104, weather: CloudyNight}
+    - {seed: 105, weather: CloudyNight}
+    - {seed: 106, weather: CloudyNight}
+    - {seed: 107, weather: WetCloudyNoon}
+    - {seed: 108, weather: WetCloudyNoon}
+    - {seed: 109, weather: WetCloudyNoon}
+
+  # Run-level split (no frame leakage between train and val).
+  # Val picks one run per weather preset for held-out weather coverage.
+  val_seeds: [103, 106, 109]

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -33,22 +33,26 @@ One row per `scripts/NN_*.py`. "Produces" names the durable artifact the experim
 | 04 | `adaptive_altitude` | SIM-11..14: adaptive altitude via `world.cast_ray()`, hybrid physics anchored on hero | ✅ | — |
 | 05 | `capture_eval_set` | CARLA pursuit eval holdout — 200 frames + YOLO labels + manifest | ✅ | `output/eval/carla_eval/` (200 jpg + 200 txt + manifest.json) |
 | 06 | `yolo_baseline` | Pretrained YOLOv8s in-loop baseline — FPS/VRAM/mAP on exp 05 holdout | ✅ | `output/eval/baseline_metrics.json` |
-| 07 | `finetune_yolo` | Fine-tune YOLOv8s on CARLA-captured pursuit data (in-app recording hook), re-score against holdout | ⬜ | `output/weights/best.pt` + `output/eval/fine_tuned_metrics.json` |
-| 08 | `yolo_inloop` | Fine-tuned weights live, boxes + conf overlaid on MJPEG (compare vs baseline visually and in FPS) | ⬜ | — |
-| 09 | `bytetrack` | Multi-object tracker on top of detections — persistent track IDs | ⬜ | — |
-| 10 | `fingerprint` | HSV colour + geometry attributes per track (CV-11..16) | ⬜ | — |
-| 11 | `mission_tracer` | First end-to-end mission slice: dispatch → detect → track → mission-end | ⬜ | — |
-| 12 | `dashboard_scoring` | Streamlit + event bus + scoring + debrief | ⬜ | — |
+| 07 | `collect_training_data` | CARLA pursuit dataset — 10 runs × 500 frames across 3 weather presets | ✅ | `output/dataset/carla_pursuit/` (5000 jpg + 5000 txt + dataset_manifest.json) |
+| 08 | `finetune_yolo` | Fine-tune YOLOv8s on exp 07 dataset, score against exp 05 holdout | ⬜ | `output/weights/best.pt` + `output/eval/fine_tuned_metrics.json` |
+| 09 | `yolo_inloop` | Fine-tuned weights live, boxes + conf overlaid on MJPEG (compare vs baseline visually and in FPS) | ⬜ | — |
+| 10 | `bytetrack` | Multi-object tracker on top of detections — persistent track IDs | ⬜ | — |
+| 11 | `fingerprint` | HSV colour + geometry attributes per track (CV-11..16) | ⬜ | — |
+| 12 | `mission_tracer` | First end-to-end mission slice: dispatch → detect → track → mission-end | ⬜ | — |
+| 13 | `dashboard_scoring` | Streamlit + event bus + scoring + debrief | ⬜ | — |
 
 ## Currently
 
 - [x] Exp 05 — CARLA pursuit eval holdout (200 frames, all 4 classes represented)
 - [x] Exp 06 — Pretrained baseline: 26 FPS sustained, mAP@0.5 = 4.95% single-class (pretrained does not recognise aerial vehicles — ~5% recall is the real problem, class confusion is now off the board per D-09)
-- [ ] **Exp 07 — Fine-tune YOLOv8s on in-app-captured CARLA pursuit data** (next; exp 06 confirmed pretrained baseline is not sufficient)
-- [ ] Exp 08 — fine-tuned weights in live pipeline (visual + FPS comparison vs baseline)
-- [ ] Exp 09 — ByteTrack integration
-- [ ] Exp 10 — fingerprint
-- [ ] Exp 11 — first end-to-end mission
+- [x] Exp 07 — Training-data collection: 5000 frames across 10 runs, 3 weather presets, ~22,000 labels all class-0
+- [ ] **Literature survey PR** — grounds requirements in actual citations before more experiments; revisits REQUIREMENTS.md in light of findings
+- [ ] **SIGABRT teardown fix** — proper fix for the `set_actor_simulate_physics` registry race on run cleanup (tracked for after survey)
+- [ ] Exp 08 — Fine-tune YOLOv8s on the exp 07 dataset
+- [ ] Exp 09 — fine-tuned weights in live pipeline (visual + FPS comparison vs baseline)
+- [ ] Exp 10 — ByteTrack integration
+- [ ] Exp 11 — fingerprint
+- [ ] Exp 12 — first end-to-end mission
 - [ ] Follow-up chore — convert scripts 01–05 to `logging` (script 06 already on it)
 
 ### Detection baseline — exp 06 numbers (single-class taxonomy)
@@ -64,7 +68,19 @@ Re-run after the taxonomy collapse to single-class `vehicle` (design D-09). Pret
 | mAP@0.5:0.95 | 0.041 | — | ❌ |
 | Predictions vs ground truths | 37 / 804 | — | Recall ≈ 4.6% — pretrained genuinely does not recognise aerial vehicles |
 
-**Interpretation:** the pipeline works end-to-end at speed but the pretrained model sees only a tiny fraction of vehicles. The 4-class → 1-class collapse removed class-confusion as a confounding factor; the remaining 95% gap is pure recall. Exp 07 targets this directly via in-domain CARLA fine-tuning.
+**Interpretation:** the pipeline works end-to-end at speed but the pretrained model sees only a tiny fraction of vehicles. The 4-class → 1-class collapse removed class-confusion as a confounding factor; the remaining 95% gap is pure recall. Exp 08 targets this directly via in-domain CARLA fine-tuning.
+
+### Training dataset — exp 07 numbers
+
+Collected over 10 independent pursuits on Town10HD_Opt (seeds 100–109, distinct from the exp 05 eval seed = 42):
+
+| Split | Runs | Frames | Vehicle labels | Weather coverage |
+|---|---|---|---|---|
+| Train | 7 | 3,500 | ~16,000 | ClearNoon ×3 · CloudyNight ×2 · WetCloudyNoon ×2 |
+| Val | 3 | 1,500 | ~6,400 | ClearNoon ×1 · CloudyNight ×1 · WetCloudyNoon ×1 |
+| **Total** | **10** | **5,000** | **~22,400** | — |
+
+Diverse suspect vehicles drawn across runs (Ford Crown, Dodge Charger, Carlacola, VW T2, Mercedes Coupe, Microlino, etc.) so the detector isn't structurally biased toward any one make/model being "the target." Run-level split (not frame-level) enforced — train and val share zero frames. Each run per-run manifest records the seed, weather, per-frame camera pose, and class-count stats. Capture wall-clock: ~28 minutes for the full sweep.
 
 ### Known gaps / debt
 
@@ -78,6 +94,7 @@ Re-run after the taxonomy collapse to single-class `vehicle` (design D-09). Pret
 
 Reverse chronological. One line per landed PR.
 
+- **2026-04-20** · #11 — Exp 07: training-data collection (5000 frames, 10 runs, 3 weather presets); `skycop.cv.capture` helper + subprocess-per-run orchestrator; SIGABRT on CARLA teardown worked around but flagged for proper fix
 - **2026-04-20** · #9 — Detector taxonomy collapsed to single-class `vehicle`; fingerprint classes preserved for CV-12; eval holdout + baseline re-run under new taxonomy; design log D-09
 - **2026-04-20** · #7 — Exp 06: pretrained YOLOv8s baseline (FPS/VRAM + mAP on holdout); design log D-08; `skycop.logs` + `skycop.cv.inference` + `skycop.cv.eval`
 - **2026-04-20** · #5 — Aerial camera pitch −90° → −75° (design log D-07); eval holdout regenerated under the new operational distribution

--- a/scripts/05_capture_eval_set.py
+++ b/scripts/05_capture_eval_set.py
@@ -11,228 +11,51 @@ Output:
     labels/frame_NNNN.txt
     manifest.json
 
-This set is consumed by experiment 06 (VisDrone fine-tune) as a frozen eval
-benchmark — pretrained vs fine-tuned vs later rounds are all scored against
-these exact frames so progress is measurable. Do not regenerate casually.
+This set is consumed by experiment 06 (pretrained baseline) and experiment
+08 (fine-tuned scoring) as a frozen eval benchmark — same exact frames scored
+against every round of training. Do not regenerate casually.
 """
 
-import queue
-import random
+import logging
 import time
 from pathlib import Path
 
-import carla
-import cv2
-
 from skycop.config import load
-from skycop.control import AdaptiveAltitudeController, AltitudeConfig
-from skycop.cv import (
-    CLASS_NAMES,
-    DatasetManifest,
-    detector_class_for,
-    extract_yolo_labels_from_seg,
-    write_yolo_label,
-)
-from skycop.sim import (
-    SuspectParams,
-    carla_image_to_bgr,
-    connect,
-    destroy_all,
-    spawn_aerial_camera,
-    spawn_npcs,
-    spawn_reckless_suspect,
-    synchronous_mode,
-)
+from skycop.cv.capture import reset_world, run_capture
+from skycop.logs import setup_logging
+from skycop.sim import connect
 
-
-def ensure_map(client, map_name):
-    world = client.get_world()
-    if map_name in world.get_map().name:
-        return world
-    print(f"Loading {map_name}...")
-    return client.load_world(map_name)
-
-
-def make_actor_classifier(world):
-    """Return a cached actor_id → detector-class-index callable.
-
-    Every detected vehicle maps to the single detector class (index 0).
-    The fine-grained fingerprint class (car/van/truck/bus) is still
-    available via ``classify_blueprint`` and will be recorded into the
-    manifest at fingerprint integration time, not here.
-    """
-    cache: dict[int, int | None] = {}
-
-    def classify(aid: int) -> int | None:
-        if aid in cache:
-            return cache[aid]
-        actor = world.get_actor(aid)
-        if actor is None or not actor.type_id.startswith("vehicle."):
-            cache[aid] = None
-            return None
-        wheels = int(actor.attributes.get("number_of_wheels", "4"))
-        idx = detector_class_for(actor.type_id, wheels)
-        cache[aid] = idx
-        return idx
-
-    return classify
-
-
-def spawn_instance_seg_camera(world, width: int, height: int, fov: int):
-    bp_lib = world.get_blueprint_library()
-    bp = bp_lib.find("sensor.camera.instance_segmentation")
-    bp.set_attribute("image_size_x", str(width))
-    bp.set_attribute("image_size_y", str(height))
-    bp.set_attribute("fov", str(fov))
-    # Initial spawn transform — overwritten every tick by the main loop.
-    transform = carla.Transform(carla.Location(0, 0, 100), carla.Rotation(pitch=-75))
-    cam = world.spawn_actor(bp, transform)
-    q: queue.Queue[carla.Image] = queue.Queue()
-    cam.listen(q.put)
-    return cam, q
-
-
-def run(cfg):
-    rng = random.Random(cfg.seed)
-    actors: list[carla.Actor] = []
-    client = connect(host=cfg.carla.host, port=cfg.carla.port)
-    world = ensure_map(client, cfg.carla.map)
-
-    out_dir = Path(cfg.eval_capture.output_dir)
-    img_dir = out_dir / "images"
-    lbl_dir = out_dir / "labels"
-    img_dir.mkdir(parents=True, exist_ok=True)
-    lbl_dir.mkdir(parents=True, exist_ok=True)
-
-    manifest = DatasetManifest(
-        seed=cfg.seed,
-        fixed_delta_seconds=cfg.carla.fixed_delta_seconds,
-        map_name=cfg.carla.map,
-        class_names=list(CLASS_NAMES),
-        min_pixel=int(cfg.eval_capture.min_bbox_pixel),
-        min_visibility=float(cfg.eval_capture.min_visibility),
-    )
-
-    with synchronous_mode(world, cfg.carla.fixed_delta_seconds):
-        tm = client.get_trafficmanager(cfg.carla.tm_port)
-        tm.set_synchronous_mode(True)
-        tm.set_random_device_seed(cfg.seed)
-
-        try:
-            npcs, remaining = spawn_npcs(world, tm, cfg.scene.npc_count, rng)
-            actors.extend(npcs)
-            print(f"Spawned {len(npcs)}/{cfg.scene.npc_count} NPCs")
-
-            suspect_params = SuspectParams(**dict(cfg.scene.suspect))
-            suspect = spawn_reckless_suspect(world, tm, remaining, rng, suspect_params)
-            actors.append(suspect)
-            print(f"Spawned suspect {suspect.type_id} (id={suspect.id})")
-
-            tm.set_hybrid_physics_mode(True)
-            tm.set_hybrid_physics_radius(100.0)
-
-            rgb_cam, rgb_q = spawn_aerial_camera(
-                world,
-                width=cfg.camera.width, height=cfg.camera.height, fov=cfg.camera.fov,
-            )
-            actors.append(rgb_cam)
-
-            seg_cam, seg_q = spawn_instance_seg_camera(
-                world,
-                width=cfg.camera.width, height=cfg.camera.height, fov=cfg.camera.fov,
-            )
-            actors.append(seg_cam)
-
-            altitude_ctrl = AdaptiveAltitudeController(world, AltitudeConfig(**dict(cfg.altitude)))
-            classify = make_actor_classifier(world)
-
-            target_frames = int(cfg.eval_capture.target_frames)
-            max_ticks = int(cfg.eval_capture.max_ticks)
-            subsample = int(cfg.eval_capture.subsample_every)
-            jpeg_q = int(cfg.eval_capture.jpeg_quality)
-
-            saved = 0
-            print(f"Capturing up to {target_frames} frames (max {max_ticks} ticks)…")
-            t0 = time.time()
-
-            for tick in range(max_ticks):
-                loc = suspect.get_transform().location
-                target_z, _ = altitude_ctrl.step(loc.x, loc.y)
-                pose = carla.Transform(
-                    carla.Location(loc.x, loc.y, target_z),
-                    carla.Rotation(pitch=cfg.camera.pitch, yaw=0, roll=0),
-                )
-                rgb_cam.set_transform(pose)
-                seg_cam.set_transform(pose)
-
-                world.tick()
-
-                try:
-                    rgb_img = rgb_q.get(timeout=2.0)
-                    seg_img = seg_q.get(timeout=2.0)
-                except queue.Empty:
-                    continue
-
-                if tick % subsample != 0:
-                    continue
-
-                seg_bgr = carla_image_to_bgr(seg_img)
-                boxes, stats = extract_yolo_labels_from_seg(
-                    seg_bgr,
-                    classify,
-                    min_pixel=int(cfg.eval_capture.min_bbox_pixel),
-                    min_visibility=float(cfg.eval_capture.min_visibility),
-                )
-                if not boxes:
-                    continue
-
-                rgb_bgr = carla_image_to_bgr(rgb_img)
-                frame_id = f"frame_{saved:04d}"
-                cv2.imwrite(
-                    str(img_dir / f"{frame_id}.jpg"),
-                    rgb_bgr,
-                    [cv2.IMWRITE_JPEG_QUALITY, jpeg_q],
-                )
-                write_yolo_label(lbl_dir / f"{frame_id}.txt", boxes)
-
-                manifest.record_frame(
-                    index=saved,
-                    tick=tick,
-                    camera_pose={
-                        "x": loc.x, "y": loc.y, "z": target_z,
-                        "pitch": float(cfg.camera.pitch), "yaw": 0.0,
-                    },
-                    suspect_pose={"x": loc.x, "y": loc.y, "z": loc.z},
-                    boxes=boxes,
-                    stats=stats,
-                )
-
-                saved += 1
-                if saved % 25 == 0:
-                    print(f"  {saved}/{target_frames} …")
-                if saved >= target_frames:
-                    break
-
-            elapsed = time.time() - t0
-            print(f"Captured {saved} frames in {elapsed:.1f}s ({saved / elapsed:.2f} fps)")
-
-            manifest.save(out_dir / "manifest.json")
-            print(f"Manifest  → {out_dir / 'manifest.json'}")
-            print(f"Class counts: {manifest.class_counts}")
-            print(f"Skip counts:  {manifest.skip_counts}")
-
-        finally:
-            destroy_all(actors)
-            try:
-                tm.set_synchronous_mode(False)
-                tm.set_hybrid_physics_mode(False)
-            except Exception:
-                pass
+log = logging.getLogger("exp05")
 
 
 def main():
+    setup_logging()
     cfg = load("default", "altitude", "eval_capture")
-    run(cfg)
+    client = connect(host=cfg.carla.host, port=cfg.carla.port)
+
+    # Ensure a clean world state before we start — prior runs leave orphan
+    # sensors on CARLA's registry (carla_caveats §6).
+    cleared = reset_world(client, cfg.carla.tm_port)
+    if cleared:
+        log.info("reset world: destroyed %d orphan actors/sensors", cleared)
+    time.sleep(0.5)
+
+    result = run_capture(
+        cfg,
+        output_dir=Path(cfg.eval_capture.output_dir),
+        client=client,
+        run_id="eval_holdout",
+        seed=cfg.seed,
+        weather="ClearNoon",
+        target_frames=int(cfg.eval_capture.target_frames),
+        subsample_every=int(cfg.eval_capture.subsample_every),
+        max_ticks=int(cfg.eval_capture.max_ticks),
+        min_bbox_pixel=int(cfg.eval_capture.min_bbox_pixel),
+        min_visibility=float(cfg.eval_capture.min_visibility),
+        jpeg_quality=int(cfg.eval_capture.jpeg_quality),
+    )
+
+    log.info("done: %d frames, skip_counts=%s", result.frames_saved, result.skip_counts)
 
 
 if __name__ == "__main__":

--- a/scripts/07_collect_training_data.py
+++ b/scripts/07_collect_training_data.py
@@ -1,0 +1,194 @@
+"""
+Experiment 07 — collect CARLA pursuit training dataset.
+
+Orchestrates N pursuit runs; **each run is isolated in its own Python
+subprocess** because CARLA's C++ SIGABRT on actor-registry teardown can
+kill the whole process on exit (bypasses Python ``try/except``). The
+parent script monitors subprocess exit codes and continues regardless.
+
+Each subprocess writes its own per-run manifest before cleanup fires;
+the parent compiles them into a combined ``dataset_manifest.json``
+after each run so a mid-loop failure preserves the work on disk.
+
+Also resumable: existing per-run manifests are reused, so a re-run
+skips already-captured pursuits.
+
+Output:
+  output/dataset/carla_pursuit/
+    run_NN_seed###_<Weather>/
+      images/, labels/, manifest.json
+    dataset_manifest.json       ← combined summary + split assignments
+
+Usage:
+  make exp N=07                 # orchestrator mode (default)
+
+Invoked internally per-run:
+  python3 scripts/07_collect_training_data.py --single-run \\
+      --run-id <id> --seed N --weather W --output-dir <path>
+"""
+
+import argparse
+import json
+import logging
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from skycop.config import load
+from skycop.cv.capture import reset_world, run_capture
+from skycop.logs import setup_logging
+from skycop.sim import connect
+
+log = logging.getLogger("exp07")
+
+
+# ── worker mode: one pursuit, one python process, exit when done ─────────
+
+def _single_run(args, cfg) -> None:
+    client = connect(host=cfg.carla.host, port=cfg.carla.port)
+    cleared = reset_world(client, cfg.carla.tm_port)
+    if cleared:
+        log.info("reset: destroyed %d orphan actors/sensors", cleared)
+    time.sleep(0.5)
+
+    result = run_capture(
+        cfg,
+        output_dir=Path(args.output_dir),
+        client=client,
+        run_id=args.run_id,
+        seed=args.seed,
+        weather=args.weather,
+        target_frames=int(cfg.training_dataset.target_frames_per_run),
+        subsample_every=int(cfg.training_dataset.subsample_every),
+        max_ticks=int(cfg.training_dataset.max_ticks_per_run),
+        min_bbox_pixel=int(cfg.training_dataset.min_bbox_pixel),
+        min_visibility=float(cfg.training_dataset.min_visibility),
+        jpeg_quality=int(cfg.training_dataset.jpeg_quality),
+    )
+    log.info("worker done: %d frames in %.1fs", result.frames_saved, result.duration_s)
+
+
+# ── orchestrator mode: spawn one subprocess per run, tolerate crashes ───
+
+def _build_dataset_manifest(results: list[dict], val_seeds: set[int]) -> dict:
+    return {
+        "runs": results,
+        "total_frames": sum(r["frames_saved"] for r in results),
+        "train_frames": sum(r["frames_saved"] for r in results if r["split"] == "train"),
+        "val_frames": sum(r["frames_saved"] for r in results if r["split"] == "val"),
+        "train_runs": [r["run_id"] for r in results if r["split"] == "train"],
+        "val_runs": [r["run_id"] for r in results if r["split"] == "val"],
+        "val_seeds": sorted(val_seeds),
+    }
+
+
+def _save_manifest_atomic(data: dict, out_path: Path) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = out_path.with_suffix(out_path.suffix + ".tmp")
+    with open(tmp, "w") as f:
+        json.dump(data, f, indent=2)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp, out_path)
+
+
+def _read_run_result(run_dir: Path, run_id: str, seed: int, weather: str, split: str) -> dict | None:
+    manifest_path = run_dir / "manifest.json"
+    if not manifest_path.exists():
+        return None
+    with open(manifest_path) as f:
+        m = json.load(f)
+    return {
+        "run_id": run_id,
+        "seed": seed,
+        "weather": weather,
+        "split": split,
+        "frames_saved": len(m.get("frames", [])),
+        "class_counts": m.get("class_counts", {}),
+        "skip_counts": m.get("skip_counts", {}),
+        "output_dir": str(run_dir),
+    }
+
+
+def _orchestrate(cfg) -> None:
+    root_out = Path(cfg.training_dataset.output_dir)
+    root_out.mkdir(parents=True, exist_ok=True)
+
+    runs_cfg = list(cfg.training_dataset.runs)
+    val_seeds = set(int(s) for s in cfg.training_dataset.val_seeds)
+
+    total_t0 = time.perf_counter()
+    results: list[dict] = []
+
+    for i, spec in enumerate(runs_cfg):
+        seed = int(spec.seed)
+        weather = str(spec.weather)
+        run_id = f"run_{i:02d}_seed{seed}_{weather}"
+        run_dir = root_out / run_id
+        split = "val" if seed in val_seeds else "train"
+
+        existing = _read_run_result(run_dir, run_id, seed, weather, split)
+        if existing is not None and existing["frames_saved"] > 0:
+            log.info("══ [%d/%d] %s  (cached: %d frames)  ══",
+                     i + 1, len(runs_cfg), run_id, existing["frames_saved"])
+            results.append(existing)
+            _save_manifest_atomic(_build_dataset_manifest(results, val_seeds),
+                                  root_out / "dataset_manifest.json")
+            continue
+
+        log.info("══ [%d/%d] %s  split=%s  ══", i + 1, len(runs_cfg), run_id, split)
+
+        cmd = [
+            sys.executable, __file__,
+            "--single-run",
+            "--run-id", run_id,
+            "--seed", str(seed),
+            "--weather", weather,
+            "--output-dir", str(run_dir),
+        ]
+        # Don't raise on non-zero exit: CARLA's SIGABRT during cleanup is
+        # expected and the manifest was already atomically written before
+        # the crash. We check for the manifest file afterwards.
+        proc = subprocess.run(cmd, check=False)
+        log.info("[%s] subprocess exit=%d", run_id, proc.returncode)
+
+        result = _read_run_result(run_dir, run_id, seed, weather, split)
+        if result is None:
+            log.warning("[%s] no manifest on disk — run yielded zero frames or crashed early",
+                        run_id)
+            continue
+
+        results.append(result)
+        _save_manifest_atomic(_build_dataset_manifest(results, val_seeds),
+                              root_out / "dataset_manifest.json")
+
+    total_elapsed = time.perf_counter() - total_t0
+    log.info("═══ done: %d/%d runs, %d total frames in %.1fs ═══",
+             len(results), len(runs_cfg),
+             sum(r["frames_saved"] for r in results),
+             total_elapsed)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--single-run", action="store_true",
+                        help="Worker mode: run one pursuit and exit (called internally).")
+    parser.add_argument("--run-id")
+    parser.add_argument("--seed", type=int)
+    parser.add_argument("--weather")
+    parser.add_argument("--output-dir")
+    args = parser.parse_args()
+
+    setup_logging()
+    cfg = load("default", "altitude", "training_dataset")
+
+    if args.single_run:
+        _single_run(args, cfg)
+    else:
+        _orchestrate(cfg)
+
+
+if __name__ == "__main__":
+    main()

--- a/skycop/cv/capture.py
+++ b/skycop/cv/capture.py
@@ -1,0 +1,299 @@
+"""Reusable single-run pursuit-capture logic.
+
+Both exp 05 (eval-holdout capture) and exp 07 (training-data collection)
+produce the same shape of artifact — RGB + YOLO-format labels + a manifest
+from a seeded pursuit run. This module is that shared path.
+
+Each call to `run_capture` runs one pursuit: sets weather, spawns the
+scene, drives the drone through the adaptive-altitude loop, captures
+paired RGB + instance-seg frames every Nth tick, extracts labels via
+`skycop.cv.dataset.extract_yolo_labels_from_seg`, and writes a manifest.
+"""
+
+from __future__ import annotations
+
+import logging
+import queue
+import random
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import carla
+import cv2
+
+from skycop.control import AdaptiveAltitudeController, AltitudeConfig
+from skycop.cv.dataset import DatasetManifest, extract_yolo_labels_from_seg, write_yolo_label
+from skycop.cv.vehicle_classes import CLASS_NAMES, detector_class_for
+from skycop.sim import (
+    SuspectParams,
+    carla_image_to_bgr,
+    destroy_all,
+    spawn_aerial_camera,
+    spawn_npcs,
+    spawn_reckless_suspect,
+    synchronous_mode,
+)
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class CaptureResult:
+    """Summary of one captured run."""
+    run_id: str
+    seed: int
+    weather: str
+    frames_saved: int
+    class_counts: dict[str, int]
+    skip_counts: dict[str, int]
+    duration_s: float
+    output_dir: Path
+
+
+def weather_preset(name: str) -> carla.WeatherParameters:
+    """Look up a CARLA weather preset by name (e.g. ``'ClearNoon'``).
+
+    Raises ``ValueError`` with a helpful message if unknown.
+    """
+    try:
+        return getattr(carla.WeatherParameters, name)
+    except AttributeError as e:
+        valid = [
+            attr for attr in dir(carla.WeatherParameters)
+            if not attr.startswith("_")
+            and isinstance(getattr(carla.WeatherParameters, attr, None), carla.WeatherParameters)
+        ]
+        raise ValueError(
+            f"Unknown weather preset '{name}'. Valid: {sorted(valid)}"
+        ) from e
+
+
+def reset_world(client: carla.Client, tm_port: int) -> int:
+    """Destroy every vehicle and sensor and put the world + TM back in async mode.
+
+    Called between runs so one run's stale actors don't haunt the next.
+    Returns the count of actors destroyed.
+    """
+    world = client.get_world()
+    settings = world.get_settings()
+    settings.synchronous_mode = False
+    settings.fixed_delta_seconds = None
+    world.apply_settings(settings)
+    try:
+        tm = client.get_trafficmanager(tm_port)
+        tm.set_synchronous_mode(False)
+        tm.set_hybrid_physics_mode(False)
+    except Exception:
+        pass
+
+    actors = list(world.get_actors().filter("vehicle.*")) + \
+             list(world.get_actors().filter("sensor.*"))
+    for a in actors:
+        try:
+            if hasattr(a, "is_listening") and a.is_listening:
+                a.stop()
+            a.destroy()
+        except Exception:
+            pass
+    return len(actors)
+
+
+def ensure_map(client: carla.Client, map_name: str) -> carla.World:
+    world = client.get_world()
+    if map_name in world.get_map().name:
+        return world
+    log.info("loading map %s", map_name)
+    return client.load_world(map_name)
+
+
+def _make_actor_classifier(world: carla.World):
+    """Cached actor_id → detector-class-index lookup for extraction callback."""
+    cache: dict[int, int | None] = {}
+
+    def classify(aid: int) -> int | None:
+        if aid in cache:
+            return cache[aid]
+        actor = world.get_actor(aid)
+        if actor is None or not actor.type_id.startswith("vehicle."):
+            cache[aid] = None
+            return None
+        wheels = int(actor.attributes.get("number_of_wheels", "4"))
+        idx = detector_class_for(actor.type_id, wheels)
+        cache[aid] = idx
+        return idx
+
+    return classify
+
+
+def _spawn_instance_seg_camera(world, width: int, height: int, fov: int):
+    bp_lib = world.get_blueprint_library()
+    bp = bp_lib.find("sensor.camera.instance_segmentation")
+    bp.set_attribute("image_size_x", str(width))
+    bp.set_attribute("image_size_y", str(height))
+    bp.set_attribute("fov", str(fov))
+    transform = carla.Transform(carla.Location(0, 0, 100), carla.Rotation(pitch=-75))
+    cam = world.spawn_actor(bp, transform)
+    q: queue.Queue[carla.Image] = queue.Queue()
+    cam.listen(q.put)
+    return cam, q
+
+
+def run_capture(
+    cfg,
+    output_dir: Path,
+    *,
+    client: carla.Client,
+    run_id: str,
+    seed: int,
+    weather: str,
+    target_frames: int,
+    subsample_every: int,
+    max_ticks: int,
+    min_bbox_pixel: int,
+    min_visibility: float,
+    jpeg_quality: int,
+) -> CaptureResult:
+    """Run one seeded pursuit, dumping paired RGB + labels + manifest to `output_dir`.
+
+    The world is assumed to be reset (no stale actors) when this is called;
+    pair with `reset_world()` between invocations when looping.
+    """
+    output_dir = Path(output_dir)
+    img_dir = output_dir / "images"
+    lbl_dir = output_dir / "labels"
+    img_dir.mkdir(parents=True, exist_ok=True)
+    lbl_dir.mkdir(parents=True, exist_ok=True)
+
+    rng = random.Random(seed)
+    actors: list[carla.Actor] = []
+
+    world = ensure_map(client, cfg.carla.map)
+    world.set_weather(weather_preset(weather))
+
+    manifest = DatasetManifest(
+        seed=seed,
+        fixed_delta_seconds=cfg.carla.fixed_delta_seconds,
+        map_name=cfg.carla.map,
+        class_names=list(CLASS_NAMES),
+        min_pixel=int(min_bbox_pixel),
+        min_visibility=float(min_visibility),
+    )
+
+    t0 = time.perf_counter()
+    saved = 0
+
+    with synchronous_mode(world, cfg.carla.fixed_delta_seconds):
+        tm = client.get_trafficmanager(cfg.carla.tm_port)
+        tm.set_synchronous_mode(True)
+        tm.set_random_device_seed(seed)
+
+        try:
+            npcs, remaining = spawn_npcs(world, tm, cfg.scene.npc_count, rng)
+            actors.extend(npcs)
+            log.info("[%s] spawned %d/%d NPCs", run_id, len(npcs), cfg.scene.npc_count)
+
+            suspect_params = SuspectParams(**dict(cfg.scene.suspect))
+            suspect = spawn_reckless_suspect(world, tm, remaining, rng, suspect_params)
+            actors.append(suspect)
+            log.info("[%s] spawned suspect %s (id=%d)", run_id, suspect.type_id, suspect.id)
+
+            tm.set_hybrid_physics_mode(True)
+            tm.set_hybrid_physics_radius(100.0)
+
+            rgb_cam, rgb_q = spawn_aerial_camera(
+                world, width=cfg.camera.width, height=cfg.camera.height, fov=cfg.camera.fov,
+            )
+            actors.append(rgb_cam)
+
+            seg_cam, seg_q = _spawn_instance_seg_camera(
+                world, width=cfg.camera.width, height=cfg.camera.height, fov=cfg.camera.fov,
+            )
+            actors.append(seg_cam)
+
+            altitude_ctrl = AdaptiveAltitudeController(world, AltitudeConfig(**dict(cfg.altitude)))
+            classify = _make_actor_classifier(world)
+
+            log.info("[%s] capturing up to %d frames…", run_id, target_frames)
+
+            for tick in range(max_ticks):
+                loc = suspect.get_transform().location
+                target_z, _ = altitude_ctrl.step(loc.x, loc.y)
+                pose = carla.Transform(
+                    carla.Location(loc.x, loc.y, target_z),
+                    carla.Rotation(pitch=cfg.camera.pitch, yaw=0, roll=0),
+                )
+                rgb_cam.set_transform(pose)
+                seg_cam.set_transform(pose)
+
+                world.tick()
+
+                try:
+                    rgb_img = rgb_q.get(timeout=2.0)
+                    seg_img = seg_q.get(timeout=2.0)
+                except queue.Empty:
+                    continue
+
+                if tick % subsample_every != 0:
+                    continue
+
+                seg_bgr = carla_image_to_bgr(seg_img)
+                boxes, stats = extract_yolo_labels_from_seg(
+                    seg_bgr, classify,
+                    min_pixel=int(min_bbox_pixel),
+                    min_visibility=float(min_visibility),
+                )
+                if not boxes:
+                    continue
+
+                rgb_bgr = carla_image_to_bgr(rgb_img)
+                frame_id = f"frame_{saved:04d}"
+                cv2.imwrite(
+                    str(img_dir / f"{frame_id}.jpg"),
+                    rgb_bgr,
+                    [cv2.IMWRITE_JPEG_QUALITY, jpeg_quality],
+                )
+                write_yolo_label(lbl_dir / f"{frame_id}.txt", boxes)
+
+                manifest.record_frame(
+                    index=saved,
+                    tick=tick,
+                    camera_pose={
+                        "x": loc.x, "y": loc.y, "z": target_z,
+                        "pitch": float(cfg.camera.pitch), "yaw": 0.0,
+                    },
+                    suspect_pose={"x": loc.x, "y": loc.y, "z": loc.z},
+                    boxes=boxes,
+                    stats=stats,
+                )
+
+                saved += 1
+                if saved >= target_frames:
+                    break
+
+            elapsed = time.perf_counter() - t0
+            log.info(
+                "[%s] captured %d frames in %.1fs (class_counts=%s)",
+                run_id, saved, elapsed, manifest.class_counts,
+            )
+
+            manifest.save(output_dir / "manifest.json")
+
+            return CaptureResult(
+                run_id=run_id,
+                seed=seed,
+                weather=weather,
+                frames_saved=saved,
+                class_counts=dict(manifest.class_counts),
+                skip_counts=dict(manifest.skip_counts),
+                duration_s=elapsed,
+                output_dir=output_dir,
+            )
+
+        finally:
+            try:
+                tm.set_hybrid_physics_mode(False)
+                tm.set_synchronous_mode(False)
+            except Exception:
+                pass
+            destroy_all(actors)

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -1,0 +1,21 @@
+"""Unit tests for the pursuit-capture helper (pure logic only, no CARLA)."""
+
+import pytest
+
+from skycop.cv.capture import weather_preset
+
+
+def test_weather_preset_returns_known_preset():
+    # This runs against the real carla module imported inside capture.py —
+    # ClearNoon exists across all 0.9.x versions.
+    import carla
+    result = weather_preset("ClearNoon")
+    assert isinstance(result, carla.WeatherParameters)
+
+
+def test_weather_preset_rejects_unknown_name_with_helpful_message():
+    with pytest.raises(ValueError) as ei:
+        weather_preset("NoSuchWeather")
+    msg = str(ei.value)
+    assert "NoSuchWeather" in msg
+    assert "Valid:" in msg


### PR DESCRIPTION
## Summary

Produces an in-domain training dataset for the detector fine-tune (exp 08). 10 independent pursuits on Town10HD_Opt (seeds 100–109, disjoint from exp 05's seed=42), 3 weather presets, ~22 400 total vehicle instances across 5000 paired RGB + YOLO label files.

Closes #11

## Dataset summary

| Split | Runs | Frames | Vehicle labels | Weather coverage |
|---|---|---|---|---|
| Train | 7 | 3,500 | ~16,000 | ClearNoon ×3 · CloudyNight ×2 · WetCloudyNoon ×2 |
| Val | 3 | 1,500 | ~6,400 | ClearNoon ×1 · CloudyNight ×1 · WetCloudyNoon ×1 |
| **Total** | **10** | **5,000** | **~22,400** | — |

Suspect variety across runs: Ford Crown, Dodge Charger, Carlacola, VW T2, Mercedes Coupe, Microlino, etc. — no single vehicle model dominates, so the detector can't overfit to "suspect = X shape".

## Architecture notes

**`skycop.cv.capture`** — extracted the per-run pursuit-capture logic from scripts/05 into a shared `run_capture(cfg, output_dir, *, seed, weather, …)`. Exp 05 is now a thin wrapper (one run, single weather); exp 07 loops over the configured run plan. Also ships `reset_world()` for orphan-actor cleanup between runs and `weather_preset()` that resolves preset names with a helpful error on typos.

**Subprocess-per-run orchestrator.** The first attempt at exp 07 crashed on the C++ SIGABRT during CARLA traffic-manager teardown — `std::terminate` bypasses Python `try/except`. The orchestrator now spawns each pursuit in its own Python subprocess, tolerates `exit=-6`, and reads the per-run manifest from disk afterward (`run_capture` atomically writes the manifest inside its try block before cleanup fires). Resumable: a re-run picks up cached per-run results and skips already-captured pursuits.

The SIGABRT is worked around here but flagged as tech debt — the underlying `set_actor_simulate_physics` registry race deserves a proper fix. Tracked for the next checkpoint after the pending literature-survey PR.

## Test plan

- [x] `make test` — 48/48 (new: weather_preset lookup + unknown-preset error)
- [x] `make lint` — clean
- [x] `make exp N=07` — all 10 runs complete; `dataset_manifest.json` reports 10/10, 3500 train frames, 1500 val frames
- [x] `awk '{print $1}' output/dataset/carla_pursuit/run_*/labels/*.txt | sort -u` → only `0` (single-class invariant holds across all 5000 labels)
- [x] No frame overlap between train and val (run-level split enforced by seed membership in `val_seeds`)
- [x] Exp 05 smoke-tested after the refactor — 200-frame eval holdout regenerates identically via the shared helper

## Known gaps (carried into issues)

- SIGABRT during pursuit cleanup (`set_actor_simulate_physics: Actor could not be found`) — real fix to come via `client.apply_batch_sync` for destroys + explicit pre-destroy physics restore. Separate issue/PR.
- Literature survey retrofit owed before exp 08 — user flagged that requirements should have been grounded in citations from day one. Separate PR, lands before fine-tuning begins.