### PR TITLE
chore: convert scripts 01–04 to skycop.logs

### DIFF
--- a/scripts/01_hello_world.py
+++ b/scripts/01_hello_world.py
@@ -1,7 +1,7 @@
 """
 Experiment 01 — Hello CARLA World
 
-Connects to the CARLA server, prints world info, spawns a vehicle with
+Connects to the CARLA server, logs world info, spawns a vehicle with
 an RGB camera, captures one frame using synchronous mode, and saves it.
 
 Key concepts:
@@ -12,25 +12,31 @@ Key concepts:
   - Proper actor cleanup (important: CARLA leaks GPU memory on sensors)
 """
 
+import logging
+import os
 import queue
 
 import carla
 
+from skycop.logs import setup_logging
 from skycop.sim import connect, synchronous_mode
 
 OUTPUT_DIR = "/app/output"
 
+log = logging.getLogger("exp01")
+
 
 def main():
+    setup_logging()
     actors = []
 
     try:
         client = connect()
         world = client.get_world()
 
-        print("Connected to CARLA!")
-        print(f"  Map:    {world.get_map().name}")
-        print(f"  Maps:   {client.get_available_maps()}")
+        log.info("connected to CARLA")
+        log.info("map:  %s", world.get_map().name)
+        log.info("maps: %s", client.get_available_maps())
 
         with synchronous_mode(world, fixed_delta_seconds=0.05):
             bp_lib = world.get_blueprint_library()
@@ -44,7 +50,7 @@ def main():
                 raise RuntimeError("Could not spawn vehicle at any point")
 
             actors.append(vehicle)
-            print(f"  Spawned: {vehicle.type_id} (id={vehicle.id})")
+            log.info("spawned: %s (id=%d)", vehicle.type_id, vehicle.id)
 
             camera_bp = bp_lib.find("sensor.camera.rgb")
             camera_bp.set_attribute("image_size_x", "1280")
@@ -63,11 +69,10 @@ def main():
 
             image = image_queue.get(timeout=5.0)
 
-            import os
             os.makedirs(OUTPUT_DIR, exist_ok=True)
             out_path = f"{OUTPUT_DIR}/01_hello_world.png"
             image.save_to_disk(out_path)
-            print(f"  Saved: {out_path} ({image.width}x{image.height})")
+            log.info("saved: %s (%dx%d)", out_path, image.width, image.height)
 
     finally:
         for actor in reversed(actors):
@@ -76,7 +81,7 @@ def main():
             except Exception:
                 pass
 
-    print("Done! Your CARLA setup is working.")
+    log.info("done — CARLA setup is working")
 
 
 if __name__ == "__main__":

--- a/scripts/02_drone_view.py
+++ b/scripts/02_drone_view.py
@@ -15,6 +15,7 @@ Controls:
   1-5     — switch maps (Town01-05)
 """
 
+import logging
 import math
 import queue
 import random
@@ -25,7 +26,10 @@ import carla
 from flask import jsonify, request
 
 from skycop.dashboard import MJPEGServer
+from skycop.logs import setup_logging
 from skycop.sim import carla_image_to_bgr, connect, spawn_aerial_camera, synchronous_mode
+
+log = logging.getLogger("exp02")
 
 # Movement settings
 MOVE_SPEED = 0.8       # metres per tick
@@ -147,7 +151,7 @@ def spawn_traffic(client, world, count=40):
             npc.set_autopilot(True, 8000)
             npc_actors.append(npc)
 
-    print(f"  Spawned {len(npc_actors)} NPC vehicles")
+    log.info("spawned %d NPC vehicles", len(npc_actors))
 
 
 def destroy_traffic():
@@ -159,7 +163,7 @@ def destroy_traffic():
             pass
     count = len(npc_actors)
     npc_actors = []
-    print(f"  Destroyed {count} NPC vehicles")
+    log.info("destroyed %d NPC vehicles", count)
 
 
 def reset_camera(world, spectator):
@@ -177,7 +181,7 @@ def carla_loop(server: MJPEGServer):
 
     client = connect()
     world = client.get_world()
-    print(f"Connected to CARLA — map: {world.get_map().name}")
+    log.info("connected to CARLA — map: %s", world.get_map().name)
 
     with synchronous_mode(world, FIXED_DT):
         spectator = world.get_spectator()
@@ -190,14 +194,14 @@ def carla_loop(server: MJPEGServer):
 
         camera, img_queue = reset_camera(world, spectator)
         map_keys = {"1": "Town01", "2": "Town02", "3": "Town03", "4": "Town04", "5": "Town05"}
-        print("Drone ready — open http://localhost:5000")
+        log.info("drone ready — open http://localhost:5000")
 
         try:
             while True:
                 # Map switch
                 for key, map_name in map_keys.items():
                     if key in keys_pressed:
-                        print(f"  Loading {map_name}...")
+                        log.info("loading %s…", map_name)
                         camera.stop()
                         camera.destroy()
                         destroy_traffic()
@@ -214,7 +218,7 @@ def carla_loop(server: MJPEGServer):
                             carla.Rotation(pitch=-30, yaw=sp.rotation.yaw),
                         ))
                         camera, img_queue = reset_camera(world, spectator)
-                        print(f"  Loaded {map_name}")
+                        log.info("loaded %s", map_name)
                         keys_pressed.discard(key)
                         break
 
@@ -283,10 +287,11 @@ def carla_loop(server: MJPEGServer):
             camera.stop()
             camera.destroy()
             destroy_traffic()
-            print("Drone stopped.")
+            log.info("drone stopped")
 
 
 def main():
+    setup_logging()
     server = MJPEGServer(title="SkyCop — Experiment 02", html=HTML_PAGE)
     # Add keyboard input route on the same Flask app.
     server.app.add_url_rule("/keys", "update_keys", update_keys, methods=["POST"])

--- a/scripts/03_suspect_and_traffic.py
+++ b/scripts/03_suspect_and_traffic.py
@@ -11,6 +11,7 @@ Closes the Environment milestone:
 Open http://localhost:5000 to watch the live top-down feed.
 """
 
+import logging
 import queue
 import random
 import time
@@ -19,6 +20,7 @@ import carla
 
 from skycop.config import load
 from skycop.dashboard import MJPEGServer
+from skycop.logs import setup_logging
 from skycop.sim import (
     SuspectParams,
     carla_image_to_bgr,
@@ -30,12 +32,14 @@ from skycop.sim import (
     teardown_pursuit,
 )
 
+log = logging.getLogger("exp03")
+
 
 def ensure_map(client, map_name):
     world = client.get_world()
     if map_name in world.get_map().name:
         return world
-    print(f"Loading {map_name}...")
+    log.info("loading map %s", map_name)
     return client.load_world(map_name)
 
 
@@ -53,12 +57,12 @@ def run(server: MJPEGServer, cfg):
         try:
             npcs, remaining = spawn_npcs(world, tm, cfg.scene.npc_count, rng)
             actors.extend(npcs)
-            print(f"Spawned {len(npcs)}/{cfg.scene.npc_count} NPCs")
+            log.info("spawned %d/%d NPCs", len(npcs), cfg.scene.npc_count)
 
             suspect_params = SuspectParams(**dict(cfg.scene.suspect))
             suspect = spawn_reckless_suspect(world, tm, remaining, rng, suspect_params)
             actors.append(suspect)
-            print(f"Spawned suspect {suspect.type_id} (id={suspect.id})")
+            log.info("spawned suspect %s (id=%d)", suspect.type_id, suspect.id)
 
             camera, img_queue = spawn_aerial_camera(
                 world,
@@ -68,7 +72,7 @@ def run(server: MJPEGServer, cfg):
             )
             actors.append(camera)
 
-            print("Running — http://localhost:5000")
+            log.info("running — http://localhost:5000")
 
             while True:
                 loc = suspect.get_transform().location
@@ -89,10 +93,11 @@ def run(server: MJPEGServer, cfg):
             pass
         finally:
             teardown_pursuit(client, world, tm, actors)
-            print("Stopped.")
+            log.info("stopped")
 
 
 def main():
+    setup_logging()
     cfg = load("default")
     server = MJPEGServer(
         title="SkyCop — Experiment 03",

--- a/scripts/04_adaptive_altitude.py
+++ b/scripts/04_adaptive_altitude.py
@@ -15,6 +15,7 @@ Config via OmegaConf:
 Open http://localhost:5000 for the top-down feed with altitude HUD.
 """
 
+import logging
 import queue
 import random
 import time
@@ -25,6 +26,7 @@ import cv2
 from skycop.config import load
 from skycop.control import AdaptiveAltitudeController, AltitudeConfig
 from skycop.dashboard import MJPEGServer
+from skycop.logs import setup_logging
 from skycop.sim import (
     SuspectParams,
     carla_image_to_bgr,
@@ -36,12 +38,14 @@ from skycop.sim import (
     teardown_pursuit,
 )
 
+log = logging.getLogger("exp04")
+
 
 def ensure_map(client, map_name):
     world = client.get_world()
     if map_name in world.get_map().name:
         return world
-    print(f"Loading {map_name}...")
+    log.info("loading map %s", map_name)
     return client.load_world(map_name)
 
 
@@ -72,12 +76,13 @@ def run(server: MJPEGServer, cfg):
         try:
             npcs, remaining = spawn_npcs(world, tm, cfg.scene.npc_count, rng)
             actors.extend(npcs)
-            print(f"Spawned {len(npcs)}/{cfg.scene.npc_count} NPCs")
+            log.info("spawned %d/%d NPCs", len(npcs), cfg.scene.npc_count)
 
             suspect_params = SuspectParams(**dict(cfg.scene.suspect))
             suspect = spawn_reckless_suspect(world, tm, remaining, rng, suspect_params)
             actors.append(suspect)
-            print(f"Spawned suspect {suspect.type_id} (id={suspect.id}) role={suspect_params.role_name}")
+            log.info("spawned suspect %s (id=%d) role=%s",
+                     suspect.type_id, suspect.id, suspect_params.role_name)
 
             # Hybrid physics anchored on the hero (the suspect) — carla_caveats §10.
             # Distant NPCs get simplified physics, freeing GPU for rendering.
@@ -95,7 +100,7 @@ def run(server: MJPEGServer, cfg):
             alt_cfg = AltitudeConfig(**dict(cfg.altitude))
             altitude_ctrl = AdaptiveAltitudeController(world, alt_cfg)
 
-            print("Running — http://localhost:5000")
+            log.info("running — http://localhost:5000")
 
             while True:
                 loc = suspect.get_transform().location
@@ -119,10 +124,11 @@ def run(server: MJPEGServer, cfg):
             pass
         finally:
             teardown_pursuit(client, world, tm, actors)
-            print("Stopped.")
+            log.info("stopped")
 
 
 def main():
+    setup_logging()
     cfg = load("default", "altitude")
     server = MJPEGServer(
         title="SkyCop — Experiment 04",


### PR DESCRIPTION
## Summary

Completes the `print` → `logging` conversion across `scripts/`. Script 06 was first; scripts 05, 07 inherited. This PR does the remaining four: 01, 02, 03, 04.

Cosmetic-only change. No behavioural impact.

Closes #17

## Test plan

- [x] `grep -rn 'print(' scripts/` returns nothing
- [x] `make test` — 48/48
- [x] `make lint` — clean
- [x] `make exp N=01` — exit 0, timestamped INFO output (matching exp 06/07 shape)
- [x] `make exp N=03` smoke test — Flask boots, HTTP 200 on `/`, structured logs visible