### PR TITLE
docs: carla caveats §6b + progress log refresh (Closes #26)

### DIFF
--- a/docs/carla_caveats.md
+++ b/docs/carla_caveats.md
@@ -62,6 +62,31 @@ Always use this sequence when you've enabled hybrid physics or when you have > ~
 
 - **Source:** [CARLA generate_traffic.py reference](https://github.com/carla-simulator/carla/blob/master/PythonAPI/examples/generate_traffic.py) · [apply_batch_sync docs](https://carla.readthedocs.io/en/0.9.16/python_api/#carla.Client.apply_batch_sync)
 
+### 6b. Dual-sensor long captures segfault CARLA on destroy
+
+Empirically verified across SkyCop exps 07, 08, 10: when a pursuit scene spawns **both** an RGB camera and an instance-segmentation camera, runs them in sync mode with every-tick capture for **≥ 250 frames**, and then invokes the §6a teardown, the CARLA server SIGSEGVs during the destroy phase:
+
+```
+carla-server-1 | Signal 11 caught.
+carla-server-1 | CommonUnixCrashHandler: Signal=11
+carla-server-1 | CarlaUE4.sh: line 5: 57 Segmentation fault (core dumped) CarlaUE4-Linux-Shipping
+```
+
+The server container exits with code 139. The Python client then blocks 60 s on the dead RPC socket and raises a C++ `carla::client::TimeoutException`, which `std::terminate`s the process (SIGABRT, exit 134) — Python's `except Exception` cannot catch it because the exception is thrown from the C++ binding layer.
+
+**Does not help:**
+
+- Moving the sensor destroy from `apply_batch_sync([DestroyActor, ...])` to per-actor `sensor.destroy()` before the batch. The server still segfaults on the first sensor.
+- Wrapping destroys in `try/except Exception`. The C++ `terminate` bypasses Python exception handling.
+
+**Root cause (inferred):** UE4 render-target cleanup for the instance-seg camera after a long run trips a use-after-free or similar memory corruption inside `CarlaUE4-Linux-Shipping`. Single-RGB captures with the same frame count and the same teardown sequence do not hit this.
+
+**Scope for SkyCop:** confined to the **offline training/eval pipeline** (`run_capture`, `run_tracking_capture` in `skycop/cv/capture.py`). The production mission uses a single RGB camera per **SIM-07**, so this bug does not affect `skycop.main` or the live-pursuit helper in `skycop/cv/inloop.py`.
+
+**Recommended workaround when a dual-sensor capture is actually needed:** do not rely on teardown at all. Run each capture in a fresh `carla-server` container and `docker compose stop carla-server` between runs — the destroy RPC is skipped entirely, the server exits cleanly when the container stops, and VRAM is reclaimed by process teardown. Costs ~15 s per run for the restart; deterministic and avoids the crash.
+
+- **Source:** empirical, SkyCop issue #25 (closed with this finding). Upstream reports of dual-sensor / instance-seg cleanup crashes: https://github.com/carla-simulator/carla/issues/5790 · https://github.com/carla-simulator/carla/issues/6073
+
 ## 7. Blueprint attribute footguns
 
 - `role_name` has no effect on simulation — it is a free-form tag you set to find your own actors later. Hero-specific behaviour only triggers when `role_name == 'hero'` for some TM heuristics.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -2,7 +2,7 @@
 
 Live state of the project: which milestones are closed, which experiments have landed, what's next. Updated inside the branch that closes each unit of work — never as a stale afterthought.
 
-**Last updated:** 2026-04-20
+**Last updated:** 2026-04-21
 
 **Legend:** ✅ complete · 🔨 in progress · ⬜ planned
 
@@ -15,9 +15,9 @@ Mirrors `REQUIREMENTS.md §14`. Each milestone is closed when its Definition of 
 | Phase | Status | DoD (abbrev.) | Evidence |
 |---|---|---|---|
 | Environment | ✅ | Town10, 50 NPCs, suspect, aerial camera streaming, adaptive altitude | exp 01–04 |
-| Detection | 🔨 | YOLOv8s fine-tuned on 4 classes (car/van/truck/bus), ByteTrack integrated, mAP ≥ 85% on CARLA holdout | exp 05 ✅ · exp 06–08 planned |
-| Suspect AI | ⬜ | 4-state FSM, dispatch / CCTV / witness events, parking lot pre-populated | — |
-| Re-ID | ⬜ | Fingerprint on first detection, occlusion recovery, parking-lot identification with confidence | — |
+| Detection | ✅ | YOLOv8s fine-tuned single-class `vehicle` (per D-09), ByteTrack integrated, mAP@0.5 = 0.962 same-map / 0.581 cross-map, suspect continuity max 0.996 | exp 05–10 ✅ |
+| Suspect AI | ⬜ | 4-state FSM, dispatch / CCTV / witness events, parking lot pre-populated | exp 12 planned |
+| Re-ID | 🔨 | Fingerprint on first detection, occlusion recovery, parking-lot identification with confidence | exp 11 planned |
 | Dashboard | ⬜ | Streamlit live, manual mode playable, scoring, debrief | — |
 | Polish | ⬜ | Demo video, README, eval JSON, Docker tested, architecture diagram | — |
 
@@ -51,9 +51,8 @@ One row per `scripts/NN_*.py`. "Produces" names the durable artifact the experim
 - [x] Exp 08 — Fine-tune YOLOv8s: same-map mAP@0.5 = 0.962, cross-map 0.581 (38-pt gap — real features learned + Town10HD overfit component). Design log D-11.
 - [x] Exp 09 — Fine-tuned in-loop inference: 25.0 FPS (baseline 26.2, delta −1.17), 13.9 ms mean detection, 0.042 GB peak VRAM — all within NFR-01/NFR-03. Live pursuit verified end-to-end.
 - [x] Exp 10 — ByteTrack + suspect-continuity eval: max continuity **0.996** (run_B), min **0.724** (run_A), mean 0.86 across 2 runs. Verdict **GOOD** (CV-07 ≥ 0.80 on at least one run).
-- [ ] **teardown_pursuit dual-sensor hang fix** — separate small PR; `apply_batch_sync` times out at 60 s after dual-RGB-seg every-tick captures; proposed fix: destroy heavy sensors individually before the batch to free render targets first.
+- [x] **teardown_pursuit dual-sensor crash — investigated, deferred.** Issue #25 attempted the "destroy sensors individually before batch" fix; E2E reproduced that the real cause is CARLA UE4 SIGSEGV (signal 11) on instance-seg camera destroy, not teardown ordering. Python client gets an uncatchable C++ `TimeoutException` → `terminate` (SIGABRT). Scope confined to dual-sensor offline captures (`run_capture`, `run_tracking_capture`); production mission uses single RGB per SIM-07 and is unaffected. Documented as `docs/carla_caveats.md` §6b. Proper workaround (server restart between runs) deferred until a new dual-sensor capture is actually needed.
 - [ ] Exp 11 — fingerprint (HSV colour + geometry, CV-11..16)
-- [ ] Exp 11 — fingerprint
 - [ ] Exp 12 — first end-to-end mission
 - [ ] Exp 11-v2 *(conditional)* — re-fine-tune with multi-map training data if exp 09 visual inspection shows the 38-pt cross-map gap is operationally problematic
 
@@ -84,7 +83,7 @@ ByteTrack (Ultralytics' bundled) on fine-tuned YOLOv8s detections. Primary metri
 
 **Verdict: GOOD** (CV-07 compliance: continuity ≥ 0.80 on at least one run). Interesting delta between runs — run_B was essentially perfect, run_A had 14 ID switches caused by 16 frames of briefly-missed detections that ByteTrack's Kalman prediction couldn't hold through. Fingerprint module (exp 11) should close this gap via appearance-based re-ID across brief loss events.
 
-Known infra issue documented alongside: **`teardown_pursuit` hangs** when capturing with dual sensors (RGB + instance-seg) at every-tick rate for 250+ frames. `apply_batch_sync` times out at 60 s and SIGABRTs the process. Data survives (tracks.json is written before teardown), but the eval runs in a separate process after captures land on disk. Proper fix (destroy heavy sensors first before the batch) queued as a separate PR.
+Known infra issue documented alongside: **CARLA UE4 segfaults on dual-sensor destroy** when capturing with RGB + instance-seg at every-tick rate for 250+ frames. Server exits with SIGSEGV (code 139); the Python client then blocks 60 s on the dead RPC and aborts via uncatchable C++ `TimeoutException` (code 134). Data survives — `tracks.json` is written before teardown. Issue #25 attempted the "destroy sensors individually first" fix and confirmed it doesn't help (server still segfaults on the individual destroy). Root cause is upstream of anything `teardown_pursuit` can do. Scope confined to the offline training/eval pipeline; production mission uses single RGB per SIM-07 and is unaffected. Documented as `docs/carla_caveats.md` §6b; workaround when next needed is server restart between runs.
 
 ### Detection in-loop — exp 09 numbers
 


### PR DESCRIPTION
## Summary

Docs-only pass capturing the #25 investigation outcome.

- **`docs/carla_caveats.md` §6b** — new subsection documenting the CARLA UE4 SIGSEGV on dual-sensor (RGB + instance-seg) destroy: reproduction signature, what does NOT help (per-actor destroy, try/except), scope (offline training/eval only — production mission uses single RGB per SIM-07), and the server-restart workaround for when a dual-sensor capture is next needed.
- **\`docs/progress.md\`:**
  - Last-updated → 2026-04-21
  - Milestones table: Detection 🔨 → ✅ (exp 05–10 landed, single-class per D-09); Re-ID ⬜ → 🔨 (exp 11 next); Suspect AI evidence → \"exp 12 planned\"
  - Currently list: the stale \"teardown hang fix — separate small PR\" entry replaced with the investigated + deferred outcome; deduped the two exp 11 fingerprint rows
  - Tracking exp 10 subsection: the \"known infra issue\" paragraph now describes the actual finding (server SIGSEGV, not a Python teardown ordering issue)

## Test plan

- [x] \`make test\` — 57/57 passing
- [x] \`make lint\` — clean
- [x] Docs render locally — markdown-preview looks right

Closes #26