### PR TITLE
feat(mission): v0 — drone-above-suspect pursuit with HSV fingerprint rebind (Closes #30)

### DIFF
--- a/configs/mission.yaml
+++ b/configs/mission.yaml
@@ -1,0 +1,19 @@
+# Mission v0 — drone-above-suspect pursuit.
+# Layered on top of configs/default.yaml + detector.yaml + training.yaml + tracking.yaml.
+
+mission:
+  duration_s: 60.0             # fixed-duration pursuit for v0 (FSM deferred)
+  altitude_m: 15.0             # SIM-11 open-road baseline; v0 pins altitude (bypasses adaptive controller)
+  weather: ClearNoon           # SIM-06 — one of ClearNoon / CloudyNight / WetCloudyNoon
+  output_root: /app/output/mission
+  video_fps: 20                # matches carla.fixed_delta_seconds = 0.05
+
+  # Correctness gate — IoU between the fingerprint-locked tracker box and
+  # the CARLA-GT projected suspect box, averaged over detected frames.
+  iou_correctness_threshold: 0.3
+  correctness_pass_bar: 0.80
+
+  fingerprint:
+    hsv_bins: 8                # 8x8x8 = 512-bin HSV histogram
+    score_threshold_rebind: 0.30  # min score to lock onto a candidate
+    score_stickiness: 0.05        # best must beat locked by this much to rebind

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -16,14 +16,24 @@ Mirrors `REQUIREMENTS.md §14`. Each milestone is closed when its Definition of 
 |---|---|---|---|
 | Environment | ✅ | Town10, 50 NPCs, suspect, aerial camera streaming, adaptive altitude | exp 01–04 |
 | Detection | ✅ | YOLOv8s fine-tuned single-class `vehicle` (per D-09), ByteTrack integrated, mAP@0.5 = 0.962 same-map / 0.581 cross-map, suspect continuity max 0.996 | exp 05–10 ✅ |
-| Suspect AI | ⬜ | 4-state FSM, dispatch / CCTV / witness events, parking lot pre-populated | exp 12 planned |
-| Re-ID | 🔨 | Fingerprint on first detection, occlusion recovery, parking-lot identification with confidence | exp 11 planned |
+| Suspect AI | ⬜ | 4-state FSM, dispatch / CCTV / witness events, parking lot pre-populated | Mission v1+ |
+| Re-ID | 🔨 | Fingerprint on first detection, occlusion recovery, parking-lot identification with confidence | Mission v0 (HSV only) ✅ · multi-attribute + dispatch bootstrap queued |
 | Dashboard | ⬜ | Streamlit live, manual mode playable, scoring, debrief | — |
 | Polish | ⬜ | Demo video, README, eval JSON, Docker tested, architecture diagram | — |
 
-## Experiments
+## Application development
 
-One row per `scripts/NN_*.py`. "Produces" names the durable artifact the experiment hands to the next step.
+Experiment phase frozen at 10b. Further work happens inside the `skycop/` package and is validated by running the live mission (`make app`) and watching the video. Decision driven by exp 10b's finding that aggregate metrics hid a violent altitude oscillation we only saw on video — offline metrics aren't enough.
+
+| Unit | Purpose | Status | Produces |
+|---|---|---|---|
+| Mission v0 | Drone pinned above suspect · fine-tuned YOLO + ByteTrack · HSV fingerprint rebind · CARLA-GT scoring | ✅ | `output/mission/<ts>/mission.mp4` + `summary.json`; correctness **0.999** on default seed (1200 frames, 60 s, bus suspect) |
+| Mission v1 | Multi-attribute fingerprint · parking-mode pitch snap (−90°) · suspect FSM states | ⬜ | — |
+| Dashboard | Streamlit + event bus + scoring + debrief | ⬜ | — |
+
+## Experiments (historical)
+
+One row per `scripts/NN_*.py`. Frozen record; no new entries. "Produces" names the durable artifact the experiment hands to the next step.
 
 | # | Script | Purpose | Status | Produces |
 |---|---|---|---|---|
@@ -54,9 +64,12 @@ One row per `scripts/NN_*.py`. "Produces" names the durable artifact the experim
 - [x] Exp 10 — ByteTrack + suspect-continuity eval: max continuity **0.996** (run_B), min **0.724** (run_A), mean 0.86 across 2 runs. Verdict **GOOD** (CV-07 ≥ 0.80 on at least one run).
 - [x] Exp 10b — tracker-trace diagnostic: `skycop/cv/tracker_viz` + `scripts/10b_tracker_trace.py`. Replays run_A through the tracker, renders an overlay video (GT bboxes + tracker bboxes + switch banner). **Findings (two, stacked):** (1) run_A's 14 id_switches are **one sustained mismatch starting at frame 233** (not 14 flickers); (2) inspecting the video exposed a **camera-altitude oscillation** in the capture itself — a 3-frame cycle of bbox heights ~40 / ~78 / ~94 px runs through the whole sequence, with the suspect bbox area growing ~30× in the 8 frames leading into frame 233. Root cause in `skycop/control/altitude.py:compute_target` — formula `s * previous + (1-s) * target` with `s = 0.2` gives 80 % weight to the new target, so `building_near` flickering between True/False drives the altitude between 15 m and 40 m tick-to-tick. The frame-233 rebind is a consequence of the scale jump, not a tracker defect. **Conclusion:** tracker is fine on this capture; exp 11 (fingerprint) is deferred until the capture itself is clean. Next unit is the altitude controller fix. Trace video: `output/eval/tracking/run_A/trace.mp4`. run_B skipped (tracks.json wiped during #25 investigation; regeneration blocked on #25 dual-sensor workaround).
 - [x] **teardown_pursuit dual-sensor crash — investigated, deferred.** Issue #25 attempted the "destroy sensors individually before batch" fix; E2E reproduced that the real cause is CARLA UE4 SIGSEGV (signal 11) on instance-seg camera destroy, not teardown ordering. Python client gets an uncatchable C++ `TimeoutException` → `terminate` (SIGABRT). Scope confined to dual-sensor offline captures (`run_capture`, `run_tracking_capture`); production mission uses single RGB per SIM-07 and is unaffected. Documented as `docs/carla_caveats.md` §6b. Proper workaround (server restart between runs) deferred until a new dual-sensor capture is actually needed.
-- [ ] Exp 11 — fingerprint (HSV colour + geometry, CV-11..16)
-- [ ] Exp 12 — first end-to-end mission
-- [ ] Exp 11-v2 *(conditional)* — re-fine-tune with multi-map training data if exp 09 visual inspection shows the 38-pt cross-map gap is operationally problematic
+- [x] **Pivot to application-driven development.** Experiments frozen at 10b. Further work lands inside `skycop/` and is validated by running `make app` and watching the video. Driven by 10b's finding that aggregate metrics hid a violent altitude oscillation — videos are now a first-class deliverable per run.
+- [x] **Mission v0** — `skycop/mission.py` + `skycop/cv/fingerprint.py` + `skycop/cv/gt_projection.py` + `configs/mission.yaml`. Drone pinned directly above suspect at 15 m / −75° (bypasses the adaptive altitude controller). Fine-tuned YOLO + ByteTrack, HSV-histogram fingerprint seeded at initial lock via CARLA-GT projection, sticky rebind each tick. Per-tick IoU correctness vs the GT-projected suspect bbox. **Result on default seed: correctness 0.999 (1198/1199) across 1200 frames / 60 s**; initial lock at frame 2; suspect was `vehicle.mitsubishi.fusorosa` (a bus — large, distinctive target, easy case). Artifacts at `output/mission/<ts>/mission.mp4` + `summary.json`. Single-sensor teardown exits clean (#25 dual-sensor bug inapplicable).
+- [ ] Mission v1 — multi-attribute fingerprint (roof shape, apparent size, speed/heading) · suspect FSM (Fleeing / Roaming / Parking / Parked) · parking-mode pitch snap to −90° (CV-26 / D-07)
+- [ ] Dispatch bootstrap — replace CARLA-GT seeding with dispatch metadata + last-known-location (FR-03)
+- [ ] Altitude-controller oscillation fix — queued for when the mission uses adaptive altitude (v0 pins it so doesn't need it)
+- [ ] Dashboard — Streamlit + event bus + scoring + debrief
 
 ### Detection baseline — exp 06 numbers (single-class taxonomy)
 

--- a/skycop/cv/fingerprint.py
+++ b/skycop/cv/fingerprint.py
@@ -1,0 +1,86 @@
+"""HSV-histogram fingerprint for re-identifying the suspect across tracker rebinds.
+
+Scope for Mission v0 is deliberately narrow: one attribute (colour), one
+distance (histogram intersection). Additional attributes (roof shape,
+apparent size, speed/heading) land when the video shows colour alone
+isn't enough — we don't speculate.
+
+Pure functions over numpy arrays; no CARLA, no YOLO.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import cv2
+import numpy as np
+
+
+@dataclass
+class Fingerprint:
+    """Normalised HSV histogram (sum = 1) flattened across H, S, V bins."""
+    hsv_hist: np.ndarray
+
+    def is_valid(self) -> bool:
+        return self.hsv_hist.size > 0 and float(self.hsv_hist.sum()) > 0.0
+
+
+def _clamp_bbox(
+    bbox: tuple[float, float, float, float], w: int, h: int
+) -> tuple[int, int, int, int] | None:
+    x1, y1, x2, y2 = bbox
+    # Reject bboxes that don't intersect the frame at all.
+    if x2 <= 0 or y2 <= 0 or x1 >= w or y1 >= h:
+        return None
+    x1i = max(0, int(x1))
+    y1i = max(0, int(y1))
+    x2i = min(w, int(x2))
+    y2i = min(h, int(y2))
+    if x2i <= x1i or y2i <= y1i:
+        return None
+    return (x1i, y1i, x2i, y2i)
+
+
+def extract(
+    frame_bgr: np.ndarray,
+    bbox: tuple[float, float, float, float],
+    bins: int = 8,
+) -> Fingerprint:
+    """HSV histogram over ``bbox`` crop of ``frame_bgr``, normalised to sum=1.
+
+    Returns a Fingerprint with an all-zero histogram for empty/off-frame
+    bboxes — callers should guard with ``is_valid()``.
+    """
+    h, w = frame_bgr.shape[:2]
+    clamped = _clamp_bbox(bbox, w, h)
+    empty = np.zeros(bins ** 3, dtype=np.float32)
+    if clamped is None:
+        return Fingerprint(empty)
+    x1, y1, x2, y2 = clamped
+    crop = frame_bgr[y1:y2, x1:x2]
+    if crop.size == 0:
+        return Fingerprint(empty)
+    hsv = cv2.cvtColor(crop, cv2.COLOR_BGR2HSV)
+    hist = cv2.calcHist(
+        [hsv], [0, 1, 2], None,
+        [bins, bins, bins],
+        [0, 180, 0, 256, 0, 256],
+    )
+    hist = hist.flatten().astype(np.float32)
+    total = float(hist.sum())
+    if total <= 0.0:
+        return Fingerprint(empty)
+    hist /= total
+    return Fingerprint(hist)
+
+
+def score(a: Fingerprint, b: Fingerprint) -> float:
+    """Histogram intersection — sum of min(a_i, b_i). Bounded 0..1 for
+    sum-normalised histograms. Symmetric; ``score(a, a) == 1.0`` iff ``a`` is valid."""
+    if not a.is_valid() or not b.is_valid():
+        return 0.0
+    if a.hsv_hist.shape != b.hsv_hist.shape:
+        raise ValueError(
+            f"Fingerprint shape mismatch: {a.hsv_hist.shape} vs {b.hsv_hist.shape}"
+        )
+    return float(np.minimum(a.hsv_hist, b.hsv_hist).sum())

--- a/skycop/cv/gt_projection.py
+++ b/skycop/cv/gt_projection.py
@@ -1,0 +1,101 @@
+"""Pinhole projection from CARLA world coordinates to image pixels.
+
+Pure numpy + math — no CARLA, no image. The caller extracts the 8 bbox
+vertices from the actor (``actor.bounding_box.get_world_vertices(actor.get_transform())``)
+and passes the camera's 4×4 world transform together with intrinsics.
+
+Axis convention: CARLA/UE4 is left-handed with X forward, Y right, Z up.
+Standard CV camera is right-handed with X right, Y down, Z forward. The
+remap ``(cam_x, cam_y, cam_z) → (cam_y, -cam_z, cam_x)`` applied here
+matches the CARLA PythonAPI ``client_bounding_boxes.py`` example.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+
+def build_camera_matrix(width: int, height: int, fov_deg: float) -> np.ndarray:
+    """Pinhole intrinsics for a CARLA camera. FOV is horizontal; pixels are square."""
+    focal = width / (2.0 * math.tan(math.radians(fov_deg) / 2.0))
+    K = np.eye(3)
+    K[0, 0] = focal
+    K[1, 1] = focal
+    K[0, 2] = width / 2.0
+    K[1, 2] = height / 2.0
+    return K
+
+
+def project_points(
+    points_world: np.ndarray,
+    world_to_camera: np.ndarray,
+    K: np.ndarray,
+) -> np.ndarray:
+    """Project (N, 3) world points to (N, 2) pixel coordinates.
+
+    Points behind the camera (z_cv ≤ 0) are returned as NaN — caller filters.
+    """
+    if points_world.ndim != 2 or points_world.shape[1] != 3:
+        raise ValueError(f"points_world must be (N, 3), got {points_world.shape}")
+    n = points_world.shape[0]
+    pts_h = np.concatenate([points_world, np.ones((n, 1))], axis=1).T  # (4, N)
+    pts_cam = world_to_camera @ pts_h                                   # (4, N)
+    # UE4 → CV frame remap: (x, y, z) → (y, -z, x)
+    x_cv = pts_cam[1]
+    y_cv = -pts_cam[2]
+    z_cv = pts_cam[0]
+    behind = z_cv <= 1e-6
+    with np.errstate(invalid="ignore", divide="ignore"):
+        u = (K[0, 0] * x_cv) / z_cv + K[0, 2]
+        v = (K[1, 1] * y_cv) / z_cv + K[1, 2]
+    u = np.where(behind, np.nan, u)
+    v = np.where(behind, np.nan, v)
+    return np.stack([u, v], axis=1)
+
+
+def world_bbox_to_image(
+    vertices_world: np.ndarray,
+    world_to_camera: np.ndarray,
+    K: np.ndarray,
+    image_size: tuple[int, int],
+) -> tuple[float, float, float, float] | None:
+    """Project 8 world-space bbox vertices to an axis-aligned image bbox.
+
+    ``image_size`` is ``(height, width)`` to match numpy/OpenCV convention.
+    Returns ``None`` if every vertex is behind the camera or the resulting
+    rectangle is empty after clipping to image bounds.
+    """
+    h, w = image_size
+    uv = project_points(vertices_world, world_to_camera, K)
+    valid = ~np.isnan(uv).any(axis=1)
+    if int(valid.sum()) == 0:
+        return None
+    us = uv[valid, 0]
+    vs = uv[valid, 1]
+    x1 = float(np.clip(us.min(), 0, w - 1))
+    y1 = float(np.clip(vs.min(), 0, h - 1))
+    x2 = float(np.clip(us.max(), 0, w - 1))
+    y2 = float(np.clip(vs.max(), 0, h - 1))
+    if x2 <= x1 or y2 <= y1:
+        return None
+    return (x1, y1, x2, y2)
+
+
+def iou_xyxy(
+    a: tuple[float, float, float, float],
+    b: tuple[float, float, float, float],
+) -> float:
+    """Axis-aligned bbox IoU. Boxes in (x1, y1, x2, y2) format."""
+    ax1, ay1, ax2, ay2 = a
+    bx1, by1, bx2, by2 = b
+    ix1, iy1 = max(ax1, bx1), max(ay1, by1)
+    ix2, iy2 = min(ax2, bx2), min(ay2, by2)
+    iw = max(0.0, ix2 - ix1)
+    ih = max(0.0, iy2 - iy1)
+    inter = iw * ih
+    area_a = max(0.0, ax2 - ax1) * max(0.0, ay2 - ay1)
+    area_b = max(0.0, bx2 - bx1) * max(0.0, by2 - by1)
+    union = area_a + area_b - inter
+    return inter / union if union > 0.0 else 0.0

--- a/skycop/main.py
+++ b/skycop/main.py
@@ -1,16 +1,18 @@
-"""SkyCop mission entrypoint — `python -m skycop.main`.
+"""SkyCop mission entrypoint — ``python -m skycop.main`` / ``make app``."""
 
-Placeholder until the full pipeline lands. For now, prints package state so
-`make app` has something real to invoke and operators can confirm the
-package is importable inside the container.
-"""
+import sys
 
-from skycop import __version__
+from skycop.config import load
+from skycop.logs import setup_logging
+from skycop.mission import run_mission
+
+sys.stdout.reconfigure(line_buffering=True)
 
 
 def main() -> None:
-    print(f"skycop v{__version__} — pipeline not yet wired.")
-    print("Run individual experiments with `make exp N=NN` (see `make exp-list`).")
+    setup_logging()
+    cfg = load("default", "detector", "training", "tracking", "mission")
+    run_mission(cfg)
 
 
 if __name__ == "__main__":

--- a/skycop/mission.py
+++ b/skycop/mission.py
@@ -1,0 +1,377 @@
+"""Mission v0 — drone-above-suspect pursuit with HSV fingerprint rebind.
+
+First vertical slice of the SkyCop application. Spawns an NPC scene and a
+reckless suspect, pins the drone directly above the suspect at a fixed
+altitude and pitch (bypassing the adaptive altitude controller so exp 10b's
+oscillation finding doesn't interfere), runs YOLO + ByteTrack, seeds an HSV
+fingerprint at initial lock, and sticky-rebinds the "suspect track_id" each
+tick against that fingerprint.
+
+Dev-mode scaffolding: CARLA's suspect ``actor_id`` is the ground truth
+both for seeding the fingerprint (at the first frame where a tracker
+bbox overlaps the GT-projected bbox) and for scoring mission correctness
+(IoU between the locked tracker bbox and the GT bbox per tick). Dispatch/
+clue-based bootstrap is deferred to a later slice.
+
+Artifacts per run, under ``output/mission/<timestamp>/``:
+
+- ``mission.mp4`` — overlay video written as-you-go.
+- ``summary.json`` — metadata + correctness score + fingerprint config.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import queue
+import random
+import time
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+
+import carla
+import cv2
+import numpy as np
+
+from skycop.cv.capture import weather_preset
+from skycop.cv.fingerprint import Fingerprint, extract, score
+from skycop.cv.gt_projection import build_camera_matrix, iou_xyxy, world_bbox_to_image
+from skycop.cv.track import ByteTrackAdapter, Track
+from skycop.dashboard import MJPEGServer
+from skycop.sim import (
+    SuspectParams,
+    carla_image_to_bgr,
+    connect,
+    spawn_aerial_camera,
+    spawn_npcs,
+    spawn_reckless_suspect,
+    synchronous_mode,
+    teardown_pursuit,
+)
+
+log = logging.getLogger(__name__)
+
+
+# ── Result types ───────────────────────────────────────────────────────
+
+@dataclass
+class MissionResult:
+    run_id: str
+    duration_s: float
+    frames_total: int
+    frames_suspect_visible: int
+    frames_locked: int
+    frames_iou_correct: int
+    correctness: float
+    initial_lock_frame: int | None
+    initial_lock_track_id: int | None
+    suspect_actor_id: int
+    suspect_type_id: str
+    seed: int
+    weather: str
+    video_path: str
+    summary_path: str
+
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+def _suspect_world_vertices(vehicle: carla.Actor) -> np.ndarray:
+    """Return (8, 3) world-space coords of the vehicle's bounding box."""
+    verts = vehicle.bounding_box.get_world_vertices(vehicle.get_transform())
+    return np.array([[v.x, v.y, v.z] for v in verts], dtype=np.float64)
+
+
+def _camera_world_matrix(camera: carla.Actor) -> np.ndarray:
+    return np.array(camera.get_transform().get_matrix(), dtype=np.float64)
+
+
+def _fmt_score(s: float) -> str:
+    return f"{s:.2f}"
+
+
+def _render_mission_overlay(
+    frame_bgr: np.ndarray,
+    gt_bbox: tuple[float, float, float, float] | None,
+    tracks: list[Track],
+    locked_track_id: int | None,
+    track_scores: dict[int, float],
+    frame_idx: int,
+    running_correctness: float | None,
+) -> np.ndarray:
+    out = frame_bgr.copy()
+    h, w = out.shape[:2]
+
+    # GT suspect (thick green)
+    if gt_bbox is not None:
+        x1, y1, x2, y2 = (int(v) for v in gt_bbox)
+        cv2.rectangle(out, (x1, y1), (x2, y2), (0, 220, 0), 3)
+        cv2.putText(out, "GT suspect", (x1, max(12, y1 - 6)),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.55, (0, 220, 0), 2, cv2.LINE_AA)
+
+    # Tracker boxes
+    for t in tracks:
+        p1 = (int(t.x1), int(t.y1))
+        p2 = (int(t.x2), int(t.y2))
+        is_locked = t.track_id is not None and t.track_id == locked_track_id
+        colour = (0, 255, 255) if is_locked else (240, 160, 40)  # yellow locked / orange otherwise
+        thick = 3 if is_locked else 2
+        cv2.rectangle(out, p1, p2, colour, thick)
+        label = f"t{t.track_id}" if t.track_id is not None else "t?"
+        fp_s = track_scores.get(t.track_id) if t.track_id is not None else None
+        if fp_s is not None:
+            label += f"  fp={_fmt_score(fp_s)}"
+        if is_locked:
+            label = "LOCKED " + label
+        cv2.putText(out, label, (p1[0], max(12, p1[1] - 6)),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.45, colour, 1, cv2.LINE_AA)
+
+    # HUD
+    cv2.putText(out, f"frame {frame_idx}", (8, h - 12),
+                cv2.FONT_HERSHEY_SIMPLEX, 0.6, (255, 255, 255), 2, cv2.LINE_AA)
+    if running_correctness is not None:
+        cv2.putText(out, f"correctness {running_correctness:.3f}", (8, h - 36),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 220, 220), 2, cv2.LINE_AA)
+    return out
+
+
+def _choose_locked_track(
+    track_scores: dict[int, float],
+    current_lock: int | None,
+    rebind_threshold: float,
+    stickiness: float,
+) -> int | None:
+    """Sticky rebind. Keep ``current_lock`` unless a candidate beats it by ``stickiness``."""
+    if not track_scores:
+        return current_lock
+    best_id, best_s = max(track_scores.items(), key=lambda kv: kv[1])
+    if current_lock is None:
+        return best_id if best_s >= rebind_threshold else None
+    cur_s = track_scores.get(current_lock)
+    if cur_s is None:
+        # Locked track has disappeared this frame — fall back to best if it passes threshold
+        return best_id if best_s >= rebind_threshold else current_lock
+    if best_id != current_lock and best_s >= rebind_threshold and (best_s - cur_s) > stickiness:
+        return best_id
+    return current_lock
+
+
+# ── Orchestrator ───────────────────────────────────────────────────────
+
+def run_mission(cfg, mjpeg_server: MJPEGServer | None = None) -> MissionResult:
+    mission_cfg = cfg.mission
+    duration_s = float(mission_cfg.duration_s)
+    altitude_m = float(mission_cfg.altitude_m)
+    weather_name = str(mission_cfg.weather)
+    iou_gate = float(mission_cfg.iou_correctness_threshold)
+    fp_cfg = mission_cfg.fingerprint
+    rebind_threshold = float(fp_cfg.score_threshold_rebind)
+    stickiness = float(fp_cfg.score_stickiness)
+    hsv_bins = int(fp_cfg.hsv_bins)
+    video_fps = int(mission_cfg.video_fps)
+
+    run_id = datetime.now().strftime("%Y%m%d_%H%M%S")
+    run_dir = Path(mission_cfg.output_root) / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    video_path = run_dir / "mission.mp4"
+    summary_path = run_dir / "summary.json"
+
+    weights_path = Path(cfg.training.project) / cfg.training.name / "weights" / "best.pt"
+    if not weights_path.exists():
+        raise FileNotFoundError(f"Fine-tuned weights missing: {weights_path}. Run exp 08.")
+
+    client = connect(host=cfg.carla.host, port=cfg.carla.port)
+    world = client.get_world()
+    if cfg.carla.map not in world.get_map().name:
+        world = client.load_world(cfg.carla.map)
+    world.set_weather(weather_preset(weather_name))
+
+    K = build_camera_matrix(int(cfg.camera.width), int(cfg.camera.height), float(cfg.camera.fov))
+    image_size = (int(cfg.camera.height), int(cfg.camera.width))
+
+    actors: list[carla.Actor] = []
+    rng = random.Random(int(cfg.seed))
+
+    with synchronous_mode(world, float(cfg.carla.fixed_delta_seconds)):
+        tm = client.get_trafficmanager(int(cfg.carla.tm_port))
+        tm.set_synchronous_mode(True)
+        tm.set_random_device_seed(int(cfg.seed))
+
+        video_writer: cv2.VideoWriter | None = None
+        try:
+            npcs, remaining = spawn_npcs(world, tm, int(cfg.scene.npc_count), rng)
+            actors.extend(npcs)
+            log.info("spawned %d/%d NPCs", len(npcs), int(cfg.scene.npc_count))
+
+            suspect_params = SuspectParams(**dict(cfg.scene.suspect))
+            suspect = spawn_reckless_suspect(world, tm, remaining, rng, suspect_params)
+            actors.append(suspect)
+            log.info("spawned suspect %s (id=%d)", suspect.type_id, suspect.id)
+
+            tm.set_hybrid_physics_mode(True)
+            tm.set_hybrid_physics_radius(100.0)
+
+            rgb_cam, rgb_q = spawn_aerial_camera(
+                world,
+                width=int(cfg.camera.width),
+                height=int(cfg.camera.height),
+                fov=int(cfg.camera.fov),
+            )
+            actors.append(rgb_cam)
+
+            adapter = ByteTrackAdapter(
+                weights=str(weights_path),
+                tracker_yaml=str(cfg.tracking.tracker_yaml),
+                conf_threshold=float(cfg.detector.conf_threshold),
+                iou_threshold=float(cfg.detector.iou_threshold),
+                input_size=int(cfg.training.imgsz),
+                device=str(cfg.training.device),
+                fp16=bool(cfg.training.half),
+            )
+
+            fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+            video_writer = cv2.VideoWriter(
+                str(video_path), fourcc, video_fps,
+                (int(cfg.camera.width), int(cfg.camera.height)),
+            )
+            if not video_writer.isOpened():
+                raise RuntimeError(f"Failed to open VideoWriter at {video_path}")
+
+            seed_fp: Fingerprint | None = None
+            locked_track_id: int | None = None
+            initial_lock_frame: int | None = None
+            initial_lock_track_id: int | None = None
+
+            frames_total = 0
+            frames_suspect_visible = 0
+            frames_locked = 0
+            frames_iou_correct = 0
+
+            target_ticks = int(duration_s / float(cfg.carla.fixed_delta_seconds))
+            log.info("mission v0: %.1fs / %d ticks / altitude=%.1fm / video → %s",
+                     duration_s, target_ticks, altitude_m, video_path)
+
+            t0 = time.perf_counter()
+            for tick in range(target_ticks):
+                loc = suspect.get_transform().location
+                pose = carla.Transform(
+                    carla.Location(loc.x, loc.y, loc.z + altitude_m),
+                    carla.Rotation(pitch=float(cfg.camera.pitch), yaw=0, roll=0),
+                )
+                rgb_cam.set_transform(pose)
+                world.tick()
+
+                try:
+                    image = rgb_q.get(timeout=2.0)
+                except queue.Empty:
+                    log.warning("tick %d: no frame", tick)
+                    continue
+                frame_bgr = carla_image_to_bgr(image)
+
+                # GT projection (done AFTER tick so the camera's world transform is current)
+                w2c = np.linalg.inv(_camera_world_matrix(rgb_cam))
+                gt_bbox = world_bbox_to_image(
+                    _suspect_world_vertices(suspect), w2c, K, image_size
+                )
+                if gt_bbox is not None:
+                    frames_suspect_visible += 1
+
+                # Detect + track
+                tracks = adapter.update(frame_bgr)
+
+                # Fingerprint bootstrap: first frame with a tracker box overlapping the GT
+                if seed_fp is None and gt_bbox is not None:
+                    for t in tracks:
+                        if t.track_id is None:
+                            continue
+                        if iou_xyxy(t.bbox, gt_bbox) >= iou_gate:
+                            seed_fp = extract(frame_bgr, t.bbox, bins=hsv_bins)
+                            if seed_fp.is_valid():
+                                locked_track_id = t.track_id
+                                initial_lock_frame = frames_total
+                                initial_lock_track_id = t.track_id
+                                log.info("initial lock: frame=%d track_id=%d",
+                                         frames_total, t.track_id)
+                                break
+
+                # Fingerprint matching + sticky rebind
+                track_scores: dict[int, float] = {}
+                if seed_fp is not None:
+                    for t in tracks:
+                        if t.track_id is None:
+                            continue
+                        cand_fp = extract(frame_bgr, t.bbox, bins=hsv_bins)
+                        track_scores[t.track_id] = score(seed_fp, cand_fp)
+                    locked_track_id = _choose_locked_track(
+                        track_scores, locked_track_id, rebind_threshold, stickiness
+                    )
+
+                # Correctness accounting
+                if locked_track_id is not None:
+                    frames_locked += 1
+                    locked_track = next(
+                        (t for t in tracks if t.track_id == locked_track_id), None
+                    )
+                    if locked_track is not None and gt_bbox is not None:
+                        if iou_xyxy(locked_track.bbox, gt_bbox) >= iou_gate:
+                            frames_iou_correct += 1
+
+                running_correctness = (
+                    frames_iou_correct / frames_suspect_visible
+                    if frames_suspect_visible > 0 else None
+                )
+                overlay = _render_mission_overlay(
+                    frame_bgr, gt_bbox, tracks, locked_track_id, track_scores,
+                    frames_total, running_correctness,
+                )
+
+                video_writer.write(overlay)
+                if mjpeg_server is not None:
+                    mjpeg_server.push(overlay)
+                frames_total += 1
+
+            elapsed = time.perf_counter() - t0
+            correctness = (
+                frames_iou_correct / frames_suspect_visible
+                if frames_suspect_visible > 0 else 0.0
+            )
+            log.info(
+                "mission done: %d frames in %.1fs · suspect-visible=%d · locked=%d · correct=%d · correctness=%.3f",
+                frames_total, elapsed, frames_suspect_visible, frames_locked,
+                frames_iou_correct, correctness,
+            )
+
+            result = MissionResult(
+                run_id=run_id,
+                duration_s=elapsed,
+                frames_total=frames_total,
+                frames_suspect_visible=frames_suspect_visible,
+                frames_locked=frames_locked,
+                frames_iou_correct=frames_iou_correct,
+                correctness=round(correctness, 4),
+                initial_lock_frame=initial_lock_frame,
+                initial_lock_track_id=initial_lock_track_id,
+                suspect_actor_id=int(suspect.id),
+                suspect_type_id=str(suspect.type_id),
+                seed=int(cfg.seed),
+                weather=weather_name,
+                video_path=str(video_path),
+                summary_path=str(summary_path),
+            )
+
+            with open(summary_path, "w") as f:
+                payload = asdict(result)
+                payload["fingerprint"] = {
+                    "hsv_bins": hsv_bins,
+                    "score_threshold_rebind": rebind_threshold,
+                    "score_stickiness": stickiness,
+                }
+                payload["iou_correctness_threshold"] = iou_gate
+                json.dump(payload, f, indent=2)
+            log.info("summary → %s", summary_path)
+            return result
+
+        finally:
+            if video_writer is not None:
+                video_writer.release()
+            teardown_pursuit(client, world, tm, actors)

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -1,0 +1,80 @@
+"""Unit tests for skycop.cv.fingerprint — pure, no CARLA, no YOLO."""
+
+import numpy as np
+import pytest
+
+from skycop.cv.fingerprint import Fingerprint, extract, score
+
+
+def _solid(bgr: tuple[int, int, int], h: int = 48, w: int = 64) -> np.ndarray:
+    img = np.zeros((h, w, 3), dtype=np.uint8)
+    img[:, :, 0] = bgr[0]
+    img[:, :, 1] = bgr[1]
+    img[:, :, 2] = bgr[2]
+    return img
+
+
+def test_extract_produces_valid_fingerprint_with_default_bins():
+    fp = extract(_solid((20, 50, 200)), bbox=(0, 0, 64, 48))
+    assert fp.is_valid()
+    assert fp.hsv_hist.shape == (8 ** 3,)
+    assert abs(float(fp.hsv_hist.sum()) - 1.0) < 1e-5
+
+
+def test_extract_empty_bbox_returns_invalid_fingerprint():
+    fp = extract(_solid((0, 0, 0)), bbox=(10, 10, 10, 10))  # zero-area
+    assert not fp.is_valid()
+    assert fp.hsv_hist.shape == (8 ** 3,)
+
+
+def test_extract_offscreen_bbox_returns_invalid_fingerprint():
+    fp = extract(_solid((0, 0, 0)), bbox=(9999, 9999, 10000, 10000))
+    assert not fp.is_valid()
+
+
+def test_extract_clamps_partially_offscreen_bbox():
+    # bbox extends past the frame but has some overlap → must still produce a valid fp
+    fp = extract(_solid((100, 100, 100)), bbox=(-20, -20, 20, 20))
+    assert fp.is_valid()
+
+
+def test_score_identical_solid_returns_one():
+    img = _solid((30, 60, 180))
+    fp = extract(img, bbox=(0, 0, 64, 48))
+    assert abs(score(fp, fp) - 1.0) < 1e-5
+
+
+def test_score_symmetric():
+    a = extract(_solid((30, 60, 180)), bbox=(0, 0, 64, 48))
+    b = extract(_solid((100, 100, 100)), bbox=(0, 0, 64, 48))
+    assert abs(score(a, b) - score(b, a)) < 1e-6
+
+
+def test_score_different_colours_less_than_one():
+    red = extract(_solid((0, 0, 220)), bbox=(0, 0, 64, 48))
+    blue = extract(_solid((220, 0, 0)), bbox=(0, 0, 64, 48))
+    assert score(red, blue) < 1.0
+    # distinct pure hues shouldn't share a single HSV bin — expect near-zero overlap
+    assert score(red, blue) < 0.1
+
+
+def test_score_bounded_0_to_1():
+    a = extract(_solid((30, 60, 180)), bbox=(0, 0, 64, 48))
+    b = extract(_solid((100, 100, 100)), bbox=(0, 0, 64, 48))
+    s = score(a, b)
+    assert 0.0 <= s <= 1.0
+
+
+def test_score_invalid_fingerprints_return_zero():
+    empty = Fingerprint(np.zeros(8 ** 3, dtype=np.float32))
+    ok = extract(_solid((50, 50, 50)), bbox=(0, 0, 64, 48))
+    assert score(empty, ok) == 0.0
+    assert score(ok, empty) == 0.0
+    assert score(empty, empty) == 0.0
+
+
+def test_score_shape_mismatch_raises():
+    a = Fingerprint(np.ones(10, dtype=np.float32) / 10.0)
+    b = Fingerprint(np.ones(20, dtype=np.float32) / 20.0)
+    with pytest.raises(ValueError):
+        score(a, b)

--- a/tests/test_gt_projection.py
+++ b/tests/test_gt_projection.py
@@ -1,0 +1,139 @@
+"""Unit tests for skycop.cv.gt_projection — pure math, no CARLA."""
+
+import math
+
+import numpy as np
+import pytest
+
+from skycop.cv.gt_projection import (
+    build_camera_matrix,
+    iou_xyxy,
+    project_points,
+    world_bbox_to_image,
+)
+
+
+def _camera_world_transform(x: float, y: float, z: float, pitch_deg: float = 0.0) -> np.ndarray:
+    """Build a 4x4 camera-to-world transform with pitch around Y (CARLA convention).
+
+    Identity orientation puts CARLA camera X forward, Y right, Z up. A
+    negative pitch tilts the camera downward (nose toward ground).
+    """
+    t = np.eye(4)
+    p = math.radians(pitch_deg)
+    # Rotation around Y axis (pitch in CARLA, left-handed): x' = cos*x + sin*z, z' = -sin*x + cos*z
+    c, s = math.cos(p), math.sin(p)
+    t[0, 0] = c
+    t[0, 2] = s
+    t[2, 0] = -s
+    t[2, 2] = c
+    t[:3, 3] = [x, y, z]
+    return t
+
+
+def test_build_camera_matrix_focal_and_principal_point():
+    K = build_camera_matrix(1280, 720, 90.0)
+    # 90° horizontal FOV → focal = W / (2 * tan(45°)) = W / 2 = 640
+    assert abs(K[0, 0] - 640.0) < 1e-6
+    assert abs(K[1, 1] - 640.0) < 1e-6
+    assert K[0, 2] == 640.0
+    assert K[1, 2] == 360.0
+
+
+def test_project_single_point_ahead_of_camera_goes_to_principal_point():
+    # Camera at origin, looking down +X (CARLA). Point on the +X axis projects
+    # to the principal point (image center).
+    K = build_camera_matrix(640, 480, 90.0)
+    cam_world = np.eye(4)   # identity = at origin, X forward
+    world_to_cam = np.linalg.inv(cam_world)
+    points = np.array([[10.0, 0.0, 0.0]])  # 10 m in front, on axis
+    uv = project_points(points, world_to_cam, K)
+    assert not np.isnan(uv).any()
+    assert abs(uv[0, 0] - K[0, 2]) < 1e-6
+    assert abs(uv[0, 1] - K[1, 2]) < 1e-6
+
+
+def test_project_point_offset_right_goes_right_of_center():
+    K = build_camera_matrix(640, 480, 90.0)
+    cam_world = np.eye(4)
+    world_to_cam = np.linalg.inv(cam_world)
+    # Shifted +Y (right in CARLA) at same forward distance — should land right of centre.
+    points = np.array([[10.0, 1.0, 0.0]])
+    uv = project_points(points, world_to_cam, K)
+    assert uv[0, 0] > K[0, 2]
+    # y unchanged (z_up is zero) → image row == principal
+    assert abs(uv[0, 1] - K[1, 2]) < 1e-6
+
+
+def test_project_point_above_goes_above_center():
+    K = build_camera_matrix(640, 480, 90.0)
+    cam_world = np.eye(4)
+    world_to_cam = np.linalg.inv(cam_world)
+    # Shifted +Z (up in CARLA) — should project ABOVE image center (lower v value).
+    points = np.array([[10.0, 0.0, 1.0]])
+    uv = project_points(points, world_to_cam, K)
+    assert abs(uv[0, 0] - K[0, 2]) < 1e-6
+    assert uv[0, 1] < K[1, 2]
+
+
+def test_project_points_behind_camera_are_nan():
+    K = build_camera_matrix(640, 480, 90.0)
+    cam_world = np.eye(4)
+    world_to_cam = np.linalg.inv(cam_world)
+    # Behind = -X in CARLA
+    points = np.array([[-5.0, 0.0, 0.0]])
+    uv = project_points(points, world_to_cam, K)
+    assert np.isnan(uv).all()
+
+
+def test_world_bbox_to_image_builds_axis_aligned_rect():
+    K = build_camera_matrix(640, 480, 90.0)
+    cam_world = np.eye(4)
+    world_to_cam = np.linalg.inv(cam_world)
+    # 8 vertices of a 2x2x2 m cube centred at (10, 0, 0)
+    cx, cy, cz = 10.0, 0.0, 0.0
+    verts = np.array([
+        [cx - 1, cy - 1, cz - 1], [cx + 1, cy - 1, cz - 1],
+        [cx - 1, cy + 1, cz - 1], [cx + 1, cy + 1, cz - 1],
+        [cx - 1, cy - 1, cz + 1], [cx + 1, cy - 1, cz + 1],
+        [cx - 1, cy + 1, cz + 1], [cx + 1, cy + 1, cz + 1],
+    ])
+    bbox = world_bbox_to_image(verts, world_to_cam, K, image_size=(480, 640))
+    assert bbox is not None
+    x1, y1, x2, y2 = bbox
+    # Cube straddles principal point in X and Y
+    assert x1 < K[0, 2] < x2
+    assert y1 < K[1, 2] < y2
+
+
+def test_world_bbox_to_image_all_behind_returns_none():
+    K = build_camera_matrix(640, 480, 90.0)
+    cam_world = np.eye(4)
+    world_to_cam = np.linalg.inv(cam_world)
+    verts = np.array([[-3, -1, -1], [-3, 1, -1], [-3, -1, 1], [-3, 1, 1]] * 2)
+    bbox = world_bbox_to_image(verts, world_to_cam, K, image_size=(480, 640))
+    assert bbox is None
+
+
+def test_project_points_wrong_shape_raises():
+    K = build_camera_matrix(640, 480, 90.0)
+    with pytest.raises(ValueError):
+        project_points(np.array([1.0, 2.0, 3.0]), np.eye(4), K)
+
+
+def test_iou_xyxy_identical_boxes_is_one():
+    box = (10.0, 10.0, 50.0, 50.0)
+    assert iou_xyxy(box, box) == 1.0
+
+
+def test_iou_xyxy_disjoint_boxes_is_zero():
+    a = (0.0, 0.0, 10.0, 10.0)
+    b = (100.0, 100.0, 110.0, 110.0)
+    assert iou_xyxy(a, b) == 0.0
+
+
+def test_iou_xyxy_half_overlap():
+    a = (0.0, 0.0, 10.0, 10.0)
+    b = (5.0, 0.0, 15.0, 10.0)
+    # overlap 5x10=50, union = 100+100-50=150 → IoU = 50/150 ≈ 0.333
+    assert abs(iou_xyxy(a, b) - 1.0 / 3.0) < 1e-6


### PR DESCRIPTION
## Summary

Pivot from experiment-driven to application-driven development. First vertical slice of the SkyCop application wires detect + track + fingerprint + CARLA-GT correctness scoring into a single orchestrator, validated by running the live mission and watching the video.

**New modules:**
- \`skycop/cv/fingerprint.py\` — HSV histogram \`extract\` + \`score\` (pure; intersection metric, 0..1)
- \`skycop/cv/gt_projection.py\` — pure pinhole projection of CARLA world-bbox → image pixels; UE4→CV axis remap; \`iou_xyxy\` utility
- \`skycop/mission.py\` — \`run_mission(cfg)\` orchestrator (spawn → pin-above-suspect → detect+track+fingerprint → correctness → video + summary → teardown)
- \`configs/mission.yaml\` — duration, altitude, weather, IoU threshold, fingerprint thresholds

\`skycop/main.py\` now calls \`run_mission\` so \`make app\` runs the mission.

## First-run result (default seed=42, ClearNoon, 60 s)

- **Correctness: 0.999** (1198/1199 IoU-correct frames)
- 1200 frames captured, 1199 with suspect visible, 1198 locked, 1198 correct
- Initial lock at frame 2, suspect = \`vehicle.mitsubishi.fusorosa\` (bus — large, distinctive, easy case)
- Artifacts: \`output/mission/20260421_171018/mission.mp4\` (200 MB overlay video) + \`summary.json\`
- Teardown exit 0 (single-sensor → #25 dual-sensor bug inapplicable)

## Acceptance criteria

- [x] \`make test\` — 86/86 pass (10 new fingerprint tests, 11 new gt_projection tests)
- [x] \`make lint\` — clean
- [x] \`make app\` — 60 s mission runs end-to-end, exits clean, produces mission.mp4 + summary.json
- [x] Correctness ≥ 0.80 on default seed (achieved 0.999 on a large-target run; future slices will hammer on harder scenarios)
- [x] \`docs/progress.md\` updated — pivot note + Mission v0 entry + milestone table refresh + "Application development" section

## Out of scope (queued)

- Multi-attribute fingerprint (roof shape, size, speed/heading) → Mission v1
- Dispatch-based bootstrap replacing CARLA-GT seeding
- Suspect FSM (Fleeing / Roaming / Parking / Parked) → Mission v1
- Altitude oscillation fix → only matters when Mission switches to adaptive altitude; v0 pins it
- Dashboard scoring UI → later milestone

Closes #30