### PR TITLE
Mission v0a: suspect FSM + vendored CARLA LocalPlanner (D-14, closes #44)

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -11,7 +11,7 @@ carla:
   fixed_delta_seconds: 0.05  # SIM-04 · 20 FPS
 
 scene:
-  npc_count: 50
+  npc_count: 20          # reduced from 50 for v0a demo — less traffic blocking the reckless suspect
   suspect:
     speed_over_pct: -80.0   # FR-08 · negative = faster, see carla_caveats §9
     ignore_lights_pct: 100.0

--- a/configs/mission.yaml
+++ b/configs/mission.yaml
@@ -2,8 +2,8 @@
 # Layered on top of configs/default.yaml + detector.yaml + training.yaml + tracking.yaml.
 
 mission:
-  duration_s: 60.0             # fixed-duration pursuit for v0 (FSM deferred)
-  altitude_m: 15.0             # SIM-11 — pinned baseline. Adaptive altitude dropped per D-12.
+  duration_s: 240.0            # safety cap (v0a FSM usually terminates earlier on AI submission or 60s PARKED timeout)
+  altitude_m: 25.0             # v0a bump 15→25 — clears the Town10HD monorail/walkway overpasses (Buildings@12.3m, RailTrack@7.2m). D-12 superseded; see issue #45 for adaptive altitude follow-up.
   weather: ClearNoon           # SIM-06 — one of ClearNoon / CloudyNight / WetCloudyNoon
   output_root: /app/output/mission
   video_fps: 20                # matches carla.fixed_delta_seconds = 0.05
@@ -26,5 +26,5 @@ mission:
 
   fingerprint:
     hsv_bins: 8                # 8x8x8 = 512-bin HSV histogram
-    score_threshold_rebind: 0.30  # min score to lock onto a candidate
-    score_stickiness: 0.05        # best must beat locked by this much to rebind
+    score_threshold_rebind: 0.50  # v0a: raised 0.30 → 0.50 to resist rebind-to-lookalike during occlusions
+    score_stickiness: 0.15        # v0a: raised 0.05 → 0.15 so current lock wins unless a candidate is clearly better

--- a/configs/suspect.yaml
+++ b/configs/suspect.yaml
@@ -1,0 +1,59 @@
+# Suspect FSM — Mission v0a (issue #44).
+# Layered on top of configs/default.yaml + mission.yaml + control.yaml.
+#
+# See docs/design.md for the design decision record (mixed time/destination
+# transitions, 60 s confirmation rule, pass/fail via bbox-centre-in-GT).
+
+suspect:
+  fsm:
+    # Time-based transitions for the "driving" states. Seed values; user
+    # is the final judge on per-state metrics per the v0a grill.
+    fleeing_duration_s: 20.0
+    roaming_duration_s: 15.0
+
+    # PARKING is destination-bound: suspect routes via GlobalRoutePlanner to
+    # the nearest parking_lots spot; if routing takes > parking_lot_timeout_s
+    # without arrival, fall back to nearest roadside_spot; if THAT also times
+    # out, the mission loop just applies full brake ("park in place").
+    parking_lot_timeout_s: 60.0
+    parking_roadside_timeout_s: 30.0
+    reach_distance_m: 5.0         # LocalPlanner typically stops ~4 m short
+    reach_speed_mps: 0.5
+
+    # PARKED 60 s window for AI-submission (K consecutive ticks of valid lock).
+    parked_confirm_timeout_s: 60.0
+    ai_consecutive_lock_ticks: 3
+
+  # Per-state TrafficManager knobs (CARLA speed convention: negative = faster).
+  # Docs/carla_caveats §9.
+  knobs:
+    fleeing:
+      speed_over_pct: -80.0           # 80 % above speed limit
+      ignore_lights_pct: 100.0
+      ignore_signs_pct: 100.0
+      lane_change_pct: 50.0
+      follow_dist_m: 1.0
+    roaming:
+      speed_over_pct: 0.0             # at the speed limit
+      ignore_lights_pct: 0.0
+      ignore_signs_pct: 0.0
+      lane_change_pct: 0.0
+      follow_dist_m: 3.0
+
+  # PARKING destinations in Town10HD — hand-picked from spawn-point survey
+  # (scripts/11_parking_scout.py --scout). Suspect picks the NEAREST lot at
+  # PARKING entry; on timeout it escalates to the nearest roadside_spot.
+  # All on Driving lanes; GlobalRoutePlanner will route to each reliably.
+  parking_lots:
+    - {x: -24.34, y: -57.79, z: 0.60}     # Town10HD south side
+    - {x:  45.77, y: 137.46, z: 0.60}     # north side
+    - {x: -41.67, y:  89.75, z: 0.60}     # central
+  roadside_spots:
+    - {x: -110.20, y:  -9.84, z: 0.60}    # west corridor
+    - {x:   99.38, y:  -6.31, z: 0.60}    # east corridor
+    - {x:  -15.15, y:  69.71, z: 0.60}    # central corridor
+
+  # Custom-controller plumbing for PARKING. See skycop/vendor/carla_agents/.
+  controller:
+    target_speed_kmh: 22.0              # LocalPlanner cruise during PARKING
+    sampling_resolution_m: 2.0          # waypoint density from GlobalRoutePlanner

--- a/configs/suspect.yaml
+++ b/configs/suspect.yaml
@@ -8,7 +8,7 @@ suspect:
   fsm:
     # Time-based transitions for the "driving" states. Seed values; user
     # is the final judge on per-state metrics per the v0a grill.
-    fleeing_duration_s: 20.0
+    fleeing_duration_s: 40.0
     roaming_duration_s: 15.0
 
     # PARKING is destination-bound: suspect routes via GlobalRoutePlanner to
@@ -28,7 +28,7 @@ suspect:
   # Docs/carla_caveats §9.
   knobs:
     fleeing:
-      speed_over_pct: -80.0           # 80 % above speed limit
+      speed_over_pct: -100.0          # 100 % above speed limit — visibly speeding
       ignore_lights_pct: 100.0
       ignore_signs_pct: 100.0
       lane_change_pct: 50.0

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -130,11 +130,11 @@ The suspect is unaware of the drone. Its behaviour is driven by a scripted finit
 
 | ID | Requirement | Status |
 |----|-------------|--------|
-| FR-07 | Suspect shall follow a 4-state FSM: **Fleeing → Roaming → Parking → Parked** | ⬜ Mission v0 uses TM autopilot with reckless knobs only |
-| FR-08 | **Fleeing:** suspect exceeds speed limit by 60–100%, runs red lights, changes lanes aggressively. The first violation triggers dispatch; after all violation reports for the current difficulty are sent, the roam timer starts. | 🔨 reckless-driving knobs in place; violation detection + dispatch pending |
-| FR-09 | **Roaming:** suspect continues driving at high speed along a randomised route through the city. This is the primary tracking window. Duration: configurable (default 60–120 seconds). | 🔨 TM reckless driving covers behaviour; FSM state + per-difficulty duration pending |
-| FR-10 | **Parking:** suspect drives to a pre-designated surface parking lot and pulls into a bay. Speed gradually decreases to normal during approach. | ⬜ |
-| FR-11 | **Parked:** suspect vehicle stops and remains stationary for the rest of the mission. The parking lot shall contain 20–40 other stationary vehicles with `set_simulate_physics(False)` to prevent drift. | ⬜ |
+| FR-07 | Suspect shall follow a 4-state FSM: **Fleeing → Roaming → Parking → Parked** | 🔨 v0a (PR #44) — `skycop.sim.suspect_fsm` ships all 4 states, mixed time/destination transitions, per-state metric breakdown |
+| FR-08 | **Fleeing:** suspect exceeds speed limit by 60–100%, runs red lights, changes lanes aggressively. The first violation triggers dispatch; after all violation reports for the current difficulty are sent, the roam timer starts. | 🔨 v0a covers reckless-driving knobs + time-based roam transition; violation detection + dispatch bootstrap (FR-03) remain pending |
+| FR-09 | **Roaming:** suspect continues driving at high speed along a randomised route through the city. This is the primary tracking window. Duration: configurable (default 60–120 seconds). | 🔨 v0a time-based (`configs/suspect.yaml:fsm.roaming_duration_s`); per-difficulty tuning pending |
+| FR-10 | **Parking:** suspect drives to a pre-designated surface parking lot and pulls into a bay. Speed gradually decreases to normal during approach. | 🔨 v0a destination-bound via vendored CARLA `GlobalRoutePlanner` + `LocalPlanner`; hand-picked waypoints (3 lots + 3 roadside spots) — lot-geometry inference still ⬜ |
+| FR-11 | **Parked:** suspect vehicle stops and remains stationary for the rest of the mission. The parking lot shall contain 20–40 other stationary vehicles with `set_simulate_physics(False)` to prevent drift. | 🔨 v0a freezes the suspect via `set_simulate_physics(False)` on PARKED entry; 20–40 parked-bystander vehicles deferred to the parking-lot-geometry follow-up |
 
 ### 3.4 Alert Events
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -442,9 +442,44 @@ Plus a per-tick `trace.jsonl` (`drone_to_suspect_m`, `center_offset_px`, `veloci
 
 ---
 
+### D-14 · Suspect FSM v0a — mixed transitions, custom PARKING controller, pass-fail confirmation
+
+**Status:** Decided · **Date:** 2026-04-22 · **Issue:** #44
+
+**Context.** Mission v1a (D-13) proved pursuit survives normal-autopilot driving (id_accuracy 0.975, track_distance p95 0.98 m). Before bootstrapping the dispatch flow we needed a gate: *if the drone can keep up through realistic suspect behaviour — aggressive, normal, parking — only then proceed*. That gate is the Suspect FSM (FR-07..11). v0a is the first slice; v0b/v0c add the menu and user-drone mode.
+
+**Decisions.**
+
+1. **Four states with mixed transition semantics.** FLEEING (time ~20 s) → ROAMING (time ~15 s) → PARKING (destination-bound) → PARKED (state-bound). Time-based FLEEING/ROAMING are sufficient for v0a metrics; PARKING is destination-bound because v0c will need a plausible parked pose for the user to click "Parked" on. Pure-time PARKING would park the suspect in the middle of a traffic lane.
+
+2. **PARKING escalation chain.** Primary target = nearest hand-picked parking-lot waypoint; on timeout, fallback to nearest roadside spot; on *that* timeout, full-brake "park in place." Either of the first two reaching destination (`dist ≤ reach_distance_m ∧ speed < reach_speed_mps`) enters PARKED. Park-in-place likewise enters PARKED once the vehicle has actually stopped. This keeps the "parks at a plausible spot" invariant without infinite mission loops when TM routing deviates.
+
+3. **Confirmation is pass-fail via bbox-centre-in-GT, not IoU.** On PARKED entry a 60 s countdown starts. AI mode submits automatically on the **first K=3 consecutive ticks of a valid lock** on the suspect track (K-voting ignores single-tick detector blips); v0c user mode will submit the drawn bbox on button click. Grading is the *same* rule in both modes: submission bbox centre must fall inside the suspect's GT-projected bbox — pass or fail, no threshold to invent. Failing to reach a parking lot is *not* a lose; only failing to confirm within 60 s post-PARKED is.
+
+4. **Custom PARKING controller via vendored CARLA LocalPlanner.** `TrafficManager.set_path()` is empirically broken in 0.9.13–0.9.16 (verified in `scripts/11_parking_scout.py` — sparse and dense waypoint lists both ignored by the TM). Route-to-destination requires bypassing the TM: at PARKING entry we `set_autopilot(False)` and drive the suspect with CARLA's own `LocalPlanner + VehiclePIDController`, fed by a `GlobalRoutePlanner` route. These live in CARLA's source tree but *not* in the pip-installed wheel, so we vendored them under `skycop/vendor/carla_agents/` (+ a three-line `_misc.py` subset + `road_option.py` enum extraction). License is MIT; `LICENSE_CARLA` records provenance. A hand-rolled pure-pursuit controller (`skycop.control.WaypointFollower`) was tried first and oscillated at tight corners — CARLA's PID is tuned for CARLA vehicle dynamics, ours was not.
+
+5. **Pure-logic FSM module, CARLA-aware mission loop.** `skycop.sim.suspect_fsm.SuspectFSM` is a pure state machine: observations in (`t`, `suspect_xy`, `suspect_speed`, `ai_lock_on_suspect`), side-effect *requests* out (`apply_tm_knobs`, `set_path_to`, `freeze_physics`). The mission loop translates those requests to CARLA calls (TM setters, LocalPlanner build, `set_simulate_physics(False)`). This keeps the FSM unit-testable with a fake clock (18 tests, no CARLA) while the mission side-effects stay at the boundary.
+
+6. **Start trigger at `POST /start`.** Mission waits on a `threading.Event` before spawning NPCs. The MJPEG server serves a splash page at `/` until the event fires, then the live feed. This is required so the operator can open the page *before* any ticks happen — useful for observation and screen capture, not for control.
+
+7. **Per-state metric breakdown in `summary.json`.** Each FSM state collects its own `{frames_total, frames_visible, id_accuracy, in_frame_rate, track_distance_mean/p95}`. Aggregate metrics still reported for continuity with v1a. Per-state numbers tell us *where* the pipeline struggles (e.g., FLEEING might drop in_frame_rate on sharp turns); aggregate numbers alone can't.
+
+8. **Exploratory metrics — no hard numeric gate.** v0a doesn't auto-pass/fail on per-state thresholds. User is final judge watching the MJPEG feed and the numbers side-by-side. Rationale: thresholds picked before data are guesses; thresholds picked from the first run are post-hoc. For v0a we just collect and look.
+
+**Deferred from v0a (explicit non-goals).**
+
+- **v0b** — menu page with mode selector, "Start" as the only control; currently the start trigger is the only UI.
+- **v0c** — user-controlled drone mode + draw-bbox submission UI for the pursuit game.
+- **FR-11 parking-lot geometry** — v0a uses hand-picked Town10HD spawn points rather than inferred lot polygons.
+- **CV-26 nadir pitch snap** — PARKED continues at pitch −75°.
+- **CV-27..32 parked-suspect re-ID** — once PARKED, tracker is still regular ByteTrack + HSV; no re-ID pipeline.
+- **Dispatch bootstrap (FR-03)** — drone still cold-starts at suspect's XY in v0a.
+
+---
+
 ## 13. Open Questions
 
-- **Suspect FSM owner.** Scripts 03/04 use TM autopilot with reckless knobs. The proper Fleeing→Roaming→Parking→Parked FSM (FR-07..11) is deferred. Lives in `skycop.sim.suspect_fsm` (module to be created) or bespoke per-script? Leaning on the module.
+- **Suspect FSM owner.** ~~Scripts 03/04 use TM autopilot with reckless knobs. The proper Fleeing→Roaming→Parking→Parked FSM (FR-07..11) is deferred.~~ Resolved by D-14 — FSM lives in `skycop.sim.suspect_fsm`, CARLA side-effects in the mission loop.
 - **Frame-level ground truth export.** For CV evaluation (CM-07..09), we'll need per-frame CARLA ground-truth dumps. Format — JSONL alongside frames, or a single run-level file? Format affects downstream tooling.
 - **Human-vs-autonomous replay.** §6.4 demands both modes play the same scenario for comparison. Do we record inputs and replay, or re-seed and re-run? Replay is robust to non-determinism in renderer (caveat §17) but requires an input-logging layer.
 - **Evaluation artifact shape.** §12 lists metrics to log; shape is undecided. A single `eval.json` per run, or time-series parquet? Small to start; parquet only if dashboards demand it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 [tool.ruff]
 line-length = 100
 target-version = "py310"
-extend-exclude = [".client-cache", "output"]
+extend-exclude = [".client-cache", "output", "skycop/vendor"]
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "UP", "B"]

--- a/scripts/11_parking_scout.py
+++ b/scripts/11_parking_scout.py
@@ -1,0 +1,320 @@
+"""Scout Town10HD spawn points for FSM parking destinations + validate TM.set_path().
+
+Two things this script answers before we commit to the destination-bound PARKING
+state in Mission v0a (issue #44):
+
+1. **Scout** — enumerate Town10HD spawn points, with their (x, y, z, yaw)
+   values, so we can hand-pick 2-3 parking-lot-ish and 2-3 roadside-ish
+   candidates for ``configs/suspect.yaml``.
+
+2. **set_path feasibility** — spawn a vehicle, call
+   ``TrafficManager.set_path(actor, [target_location])``, tick in sync mode,
+   and report whether the vehicle actually reaches the target within a
+   timeout. If no, escalate to a custom waypoint-PID controller (tracked
+   separately).
+
+Run inside the client container::
+
+    make exp N=11
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import math
+import random
+import time
+
+import carla
+
+from skycop.logs import setup_logging
+from skycop.sim import (
+    connect,
+    four_wheel_blueprints,
+    synchronous_mode,
+    teardown_pursuit,
+)
+from skycop.vendor.carla_agents import GlobalRoutePlanner, LocalPlanner
+
+log = logging.getLogger(__name__)
+
+
+def _dist2d(loc: carla.Location, target: carla.Location) -> float:
+    return math.hypot(loc.x - target.x, loc.y - target.y)
+
+
+def _scout_spawn_points(world: carla.World, n: int) -> None:
+    """Print the first ``n`` spawn points with their XY — human picks candidates."""
+    sps = world.get_map().get_spawn_points()
+    log.info("Town10HD has %d spawn points; dumping first %d", len(sps), n)
+    print(f"{'idx':>4}  {'x':>9}  {'y':>9}  {'z':>7}  {'yaw':>7}")
+    for i, sp in enumerate(sps[:n]):
+        loc = sp.location
+        rot = sp.rotation
+        print(f"{i:>4d}  {loc.x:>9.2f}  {loc.y:>9.2f}  {loc.z:>7.2f}  {rot.yaw:>7.1f}")
+
+
+def _dense_route(world: carla.World, source: carla.Location, dest: carla.Location,
+                 sampling_resolution_m: float = 2.0) -> list[carla.Location]:
+    """Dense waypoint sequence from ``source`` to ``dest`` via vendored
+    ``GlobalRoutePlanner`` (CARLA's own BFS/A* router).
+
+    Greedy ``waypoint.next()``-walking was tried first and produced
+    multi-kilometre U-shaped loops for 100 m targets (empirically observed
+    — see issue #44). The proper graph search builds a road-network
+    topology once and searches over it.
+    """
+    from skycop.vendor.carla_agents import GlobalRoutePlanner
+    grp = GlobalRoutePlanner(world.get_map(), sampling_resolution_m)
+    route = grp.trace_route(source, dest)
+    return [wp.transform.location for wp, _opt in route]
+
+
+def _test_custom_controller(
+    client: carla.Client,
+    world: carla.World,
+    source_idx: int,
+    target_idx: int,
+    timeout_s: float,
+    reach_distance_m: float,
+    reach_speed_mps: float,
+    fixed_dt: float,
+    tm_port: int,
+    sampling_resolution_m: float = 2.0,
+) -> None:
+    """Drive a vehicle with vendored CARLA LocalPlanner (autopilot OFF).
+
+    Validates option C4 of issue #44: does CARLA's own LocalPlanner +
+    VehiclePIDController drive the suspect to a destination via
+    GlobalRoutePlanner's route? This is the battle-tested CARLA solution;
+    our hand-rolled pure-pursuit ``WaypointFollower`` oscillated at tight
+    turns, so we vendor the proven controller instead.
+    """
+    sps = world.get_map().get_spawn_points()
+    source = sps[source_idx]
+    target_loc = sps[target_idx].location
+    log.info("[C4 LocalPlanner] source #%d → target #%d", source_idx, target_idx)
+
+    actors: list[carla.Actor] = []
+    with synchronous_mode(world, fixed_dt):
+        tm = client.get_trafficmanager(tm_port)
+        tm.set_synchronous_mode(True)
+
+        bp_lib = world.get_blueprint_library()
+        bp = random.Random(0).choice(four_wheel_blueprints(bp_lib))
+        bp.set_attribute("role_name", "hero")
+        vehicle = world.try_spawn_actor(bp, source)
+        if vehicle is None:
+            raise RuntimeError("Failed to spawn source vehicle")
+        actors.append(vehicle)
+        # Autopilot OFF — LocalPlanner issues apply_control() each tick.
+        vehicle.set_autopilot(False)
+
+        wmap = world.get_map()
+        grp = GlobalRoutePlanner(wmap, sampling_resolution_m)
+        route = grp.trace_route(source.location, target_loc)
+        log.info("[C4] GlobalRoutePlanner produced %d waypoints", len(route))
+
+        planner = LocalPlanner(
+            vehicle,
+            opt_dict={
+                "target_speed": 22.0,          # km/h cruise
+                "dt": fixed_dt,
+                "sampling_radius": sampling_resolution_m,
+            },
+        )
+        planner.set_global_plan(route, stop_waypoint_creation=True)
+
+        t0 = time.perf_counter()
+        ticks = 0
+        reached = False
+        dist = float("inf")
+        speed = 0.0
+        while ticks * fixed_dt < timeout_s:
+            world.tick()
+            ticks += 1
+            ctrl = planner.run_step()
+            vehicle.apply_control(ctrl)
+
+            loc = vehicle.get_location()
+            v = vehicle.get_velocity()
+            speed = math.hypot(v.x, v.y)
+            dist = math.hypot(loc.x - target_loc.x, loc.y - target_loc.y)
+            if ticks % 20 == 0:
+                log.info(
+                    "[C4] tick %4d  t=%5.1fs  pos=(%.1f,%.1f)  dist=%.2fm  speed=%.2fm/s "
+                    "throt=%.2f steer=%+.2f brake=%.2f done=%s",
+                    ticks, ticks * fixed_dt, loc.x, loc.y, dist, speed,
+                    ctrl.throttle, ctrl.steer, ctrl.brake,
+                    planner.done(),
+                )
+            if dist <= reach_distance_m and speed <= reach_speed_mps:
+                reached = True
+                break
+            if planner.done() and dist <= reach_distance_m + 3.0:
+                reached = True
+                break
+
+        wall = time.perf_counter() - t0
+        if reached:
+            log.info("[C4] ✅ REACHED in %.1fs sim-time (%.1fs wall) — %d ticks · final dist=%.2fm",
+                     ticks * fixed_dt, wall, ticks, dist)
+        else:
+            log.warning("[C4] ❌ DID NOT REACH in %.1fs — final dist=%.2fm speed=%.2fm/s",
+                        timeout_s, dist, speed)
+
+    teardown_pursuit(client, world, tm, actors)
+
+
+def _test_set_path(
+    client: carla.Client,
+    world: carla.World,
+    source_idx: int,
+    target_idx: int,
+    timeout_s: float,
+    reach_distance_m: float,
+    reach_speed_mps: float,
+    fixed_dt: float,
+    tm_port: int,
+    dense_route: bool = True,
+    sampling_resolution_m: float = 2.0,
+) -> None:
+    """Spawn a vehicle, set_path to target, tick until reached or timeout."""
+    sps = world.get_map().get_spawn_points()
+    if source_idx >= len(sps) or target_idx >= len(sps):
+        raise IndexError(f"spawn indices out of range (have {len(sps)})")
+    source = sps[source_idx]
+    target_tf = sps[target_idx]
+    target_loc = target_tf.location
+    log.info("source spawn #%d (%.1f, %.1f) → target #%d (%.1f, %.1f)",
+             source_idx, source.location.x, source.location.y,
+             target_idx, target_loc.x, target_loc.y)
+
+    actors: list[carla.Actor] = []
+    with synchronous_mode(world, fixed_dt):
+        tm = client.get_trafficmanager(tm_port)
+        tm.set_synchronous_mode(True)
+        tm.set_random_device_seed(42)
+
+        bp_lib = world.get_blueprint_library()
+        bp = random.Random(0).choice(four_wheel_blueprints(bp_lib))
+        bp.set_attribute("role_name", "hero")
+        vehicle = world.try_spawn_actor(bp, source)
+        if vehicle is None:
+            raise RuntimeError("Failed to spawn source vehicle")
+        actors.append(vehicle)
+
+        vehicle.set_autopilot(True, tm.get_port())
+        # Prevent the "stopped at a red light forever in an empty world" trap —
+        # an empty Town has no NPC flow to clear intersections.
+        tm.ignore_lights_percentage(vehicle, 100.0)
+        tm.ignore_signs_percentage(vehicle, 100.0)
+        tm.vehicle_percentage_speed_difference(vehicle, 0.0)
+        tm.set_hybrid_physics_mode(True)
+        tm.set_hybrid_physics_radius(100.0)
+
+        if dense_route:
+            path = _dense_route(world, source.location, target_loc, sampling_resolution_m)
+            log.info("GlobalRoutePlanner produced %d waypoints over %.1fm-spaced route",
+                     len(path), sampling_resolution_m)
+        else:
+            path = [target_loc]
+            log.info("using single-target path (one waypoint)")
+        tm.set_path(vehicle, path)
+        log.info("set_path called; ticking for up to %.1fs", timeout_s)
+
+        t0 = time.perf_counter()
+        ticks = 0
+        reached = False
+        elapsed = 0.0
+        dist = float("inf")
+        speed = 0.0
+        while elapsed < timeout_s:
+            world.tick()
+            ticks += 1
+            elapsed = ticks * fixed_dt
+            loc = vehicle.get_location()
+            v = vehicle.get_velocity()
+            speed = math.hypot(v.x, v.y)
+            dist = _dist2d(loc, target_loc)
+            if ticks % 20 == 0:
+                log.info(
+                    "tick %4d  t=%5.1fs  pos=(%.1f,%.1f)  dist=%.2fm  speed=%.2fm/s",
+                    ticks, elapsed, loc.x, loc.y, dist, speed,
+                )
+            if dist <= reach_distance_m and speed <= reach_speed_mps:
+                reached = True
+                break
+
+        wall_elapsed = time.perf_counter() - t0
+        if reached:
+            log.info("✅ REACHED target in %.1fs sim-time (%.1fs wall) — %d ticks · final dist=%.2fm",
+                     elapsed, wall_elapsed, ticks, dist)
+        else:
+            log.warning("❌ DID NOT REACH target in %.1fs — final dist=%.2fm speed=%.2fm/s",
+                        elapsed, dist, speed)
+            log.warning("    TM may have deviated; check `make exp N=11` output above")
+
+    teardown_pursuit(client, world, tm, actors)
+
+
+def main() -> None:
+    setup_logging()
+    parser = argparse.ArgumentParser(description="Parking scout + set_path feasibility")
+    parser.add_argument("--scout", type=int, default=40,
+                        help="Print first N spawn points for manual selection (default 40)")
+    parser.add_argument("--source", type=int, default=0, help="Source spawn-point index")
+    parser.add_argument("--target", type=int, default=10, help="Target spawn-point index")
+    parser.add_argument("--timeout", type=float, default=90.0, help="Set_path sim-time timeout (s)")
+    parser.add_argument("--reach-distance", type=float, default=3.0)
+    parser.add_argument("--reach-speed", type=float, default=0.5)
+    parser.add_argument("--skip-scout", action="store_true")
+    parser.add_argument("--skip-feasibility", action="store_true")
+    parser.add_argument("--sparse-path", action="store_true",
+                        help="Test naive single-waypoint set_path instead of dense GlobalRoutePlanner")
+    parser.add_argument("--sampling-resolution", type=float, default=2.0,
+                        help="Metres between waypoints in the dense path (default 2.0)")
+    parser.add_argument("--custom-controller", action="store_true",
+                        help="Option C3: drive via WaypointFollower (autopilot off) instead of TM")
+    parser.add_argument("--map", default="Town10HD_Opt")
+    parser.add_argument("--dt", type=float, default=0.05)
+    parser.add_argument("--tm-port", type=int, default=8000)
+    args = parser.parse_args()
+
+    client = connect()
+    world = client.get_world()
+    if args.map not in world.get_map().name:
+        log.info("loading %s", args.map)
+        world = client.load_world(args.map)
+
+    if not args.skip_scout:
+        _scout_spawn_points(world, args.scout)
+    if not args.skip_feasibility:
+        if args.custom_controller:
+            _test_custom_controller(
+                client, world,
+                source_idx=args.source, target_idx=args.target,
+                timeout_s=args.timeout,
+                reach_distance_m=args.reach_distance,
+                reach_speed_mps=args.reach_speed,
+                fixed_dt=args.dt,
+                tm_port=args.tm_port,
+                sampling_resolution_m=args.sampling_resolution,
+            )
+        else:
+            _test_set_path(
+                client, world,
+                source_idx=args.source, target_idx=args.target,
+                timeout_s=args.timeout,
+                reach_distance_m=args.reach_distance,
+                reach_speed_mps=args.reach_speed,
+                fixed_dt=args.dt,
+                tm_port=args.tm_port,
+                dense_route=not args.sparse_path,
+                sampling_resolution_m=args.sampling_resolution,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/12_overhead_scout.py
+++ b/scripts/12_overhead_scout.py
@@ -1,0 +1,174 @@
+"""Town10HD overhead-obstacle scout — prerequisite for issue #45.
+
+Queries every ``CityObjectLabel`` that could host an over-road structure
+(Buildings, RailTrack, Bridge, Static, Other), filters to objects whose
+bbox top is above typical drone pursuit altitude minus clearance, and
+keeps only those whose XY footprint overlaps a Driving lane. The output
+is the honest map D-12's audit was missing.
+
+Why: D-12 concluded "0 Bridge objects in Town10HD" and pinned altitude
+at 15 m. Mission v0a (issue #44) empirically found Town10HD's monorail
+crossings live under ``Buildings@12.3m`` + ``RailTrack@7.2m``, not Bridge
+— the audit methodology was incomplete.
+
+Run inside the client container::
+
+    docker compose exec client python3 scripts/12_overhead_scout.py
+    docker compose exec client python3 scripts/12_overhead_scout.py --min-top 5 --emit-json /app/output/scout/town10hd_overhead.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+
+import carla
+
+from skycop.logs import setup_logging
+from skycop.sim import connect
+
+log = logging.getLogger(__name__)
+
+
+# Labels that can host overhead structures in CARLA's semantic taxonomy.
+_OVERHEAD_LABELS = [
+    carla.CityObjectLabel.Buildings,
+    carla.CityObjectLabel.RailTrack,
+    carla.CityObjectLabel.Bridge,
+    carla.CityObjectLabel.Static,
+    carla.CityObjectLabel.Other,
+]
+
+
+def _is_over_driving_lane(
+    wmap: carla.Map,
+    bx: float,
+    by: float,
+    ex: float,
+    ey: float,
+) -> bool:
+    """True if the bbox XY footprint intersects any Driving-lane waypoint.
+
+    We probe the bbox centre plus four corners — cheap and sufficient for
+    the AABB approximation we're already doing.
+    """
+    probes = [
+        (bx, by),
+        (bx + ex, by + ey), (bx - ex, by + ey),
+        (bx + ex, by - ey), (bx - ex, by - ey),
+    ]
+    for px, py in probes:
+        wp = wmap.get_waypoint(
+            carla.Location(px, py, 0.0),
+            project_to_road=True,
+            lane_type=carla.LaneType.Driving,
+        )
+        if wp is not None and wp.transform.location.distance(
+            carla.Location(px, py, 0.0)
+        ) < max(ex, ey) + 1.0:
+            return True
+    return False
+
+
+def scout(
+    world: carla.World,
+    min_top_m: float,
+    pursuit_altitude_m: float,
+    clearance_margin_m: float,
+) -> list[dict]:
+    """Return a list of overhead-structure records ready for JSON export."""
+    wmap = world.get_map()
+    records: list[dict] = []
+    for label in _OVERHEAD_LABELS:
+        bbs = world.get_level_bbs(label)
+        for b in bbs:
+            z_top = b.location.z + b.extent.z
+            z_bot = b.location.z - b.extent.z
+            if z_top < min_top_m:
+                continue
+            # An overhead structure that matters is one that's above the
+            # drone (would-be occluder) or within the clearance window.
+            if z_top < pursuit_altitude_m - clearance_margin_m:
+                # Doesn't reach the drone; skip (still report if over road).
+                would_occlude = False
+            else:
+                would_occlude = True
+            if not _is_over_driving_lane(
+                wmap, b.location.x, b.location.y, b.extent.x, b.extent.y
+            ):
+                continue
+            records.append({
+                "label": str(label).split(".")[-1],
+                "xy": [round(b.location.x, 2), round(b.location.y, 2)],
+                "extent_xy": [round(b.extent.x, 2), round(b.extent.y, 2)],
+                "z_top": round(z_top, 2),
+                "z_bot": round(z_bot, 2),
+                "would_occlude_at_pursuit": would_occlude,
+            })
+    return records
+
+
+def summarise(records: list[dict], pursuit_altitude_m: float) -> None:
+    log.info("Found %d overhead-over-road records", len(records))
+    occluders = [r for r in records if r["would_occlude_at_pursuit"]]
+    log.info("  %d would occlude at pursuit altitude %.1fm", len(occluders), pursuit_altitude_m)
+
+    # Label histogram
+    from collections import Counter
+    by_label = Counter(r["label"] for r in records)
+    for label, n in by_label.most_common():
+        log.info("  %-15s n=%d", label, n)
+
+    # Top-10 tallest occluders
+    tallest = sorted(occluders, key=lambda r: -r["z_top"])[:10]
+    log.info("  top-10 tallest occluders:")
+    for r in tallest:
+        log.info(
+            "    %-10s  xy=(%7.1f, %7.1f)  extent=(%5.1f x %5.1f)  z_top=%5.2f  z_bot=%5.2f",
+            r["label"], r["xy"][0], r["xy"][1], r["extent_xy"][0], r["extent_xy"][1],
+            r["z_top"], r["z_bot"],
+        )
+
+    # Altitude needed to clear ALL overhead structures + margin
+    if occluders:
+        max_top = max(r["z_top"] for r in occluders)
+        log.info(
+            "  absolute highest over-road structure: z_top=%.2fm  "
+            "→ pursuit altitude should be ≥ %.1fm (with 5m clearance)",
+            max_top, max_top + 5.0,
+        )
+
+
+def main() -> None:
+    setup_logging()
+    parser = argparse.ArgumentParser(description="Town10HD overhead scout")
+    parser.add_argument("--map", default="Town10HD_Opt")
+    parser.add_argument("--min-top", type=float, default=3.0,
+                        help="Ignore structures whose top is below this z (m)")
+    parser.add_argument("--pursuit-altitude", type=float, default=25.0,
+                        help="Current pursuit altitude (m) — for occlusion flag")
+    parser.add_argument("--clearance", type=float, default=5.0,
+                        help="Clearance margin (m) — structures within this of pursuit altitude flagged")
+    parser.add_argument("--emit-json", type=Path,
+                        help="If set, write the full record list as JSON here")
+    args = parser.parse_args()
+
+    client = connect()
+    world = client.get_world()
+    if args.map not in world.get_map().name:
+        log.info("loading %s", args.map)
+        world = client.load_world(args.map)
+
+    records = scout(world, args.min_top, args.pursuit_altitude, args.clearance)
+    summarise(records, args.pursuit_altitude)
+
+    if args.emit_json:
+        args.emit_json.parent.mkdir(parents=True, exist_ok=True)
+        args.emit_json.write_text(json.dumps(records, indent=2))
+        log.info("wrote %d records → %s", len(records), args.emit_json)
+
+
+if __name__ == "__main__":
+    main()

--- a/skycop/dashboard/mjpeg.py
+++ b/skycop/dashboard/mjpeg.py
@@ -13,6 +13,12 @@ the index page.
 
 The server runs Flask on a daemon thread so the caller's main loop keeps
 ticking CARLA. Frames are held behind a lock and served on `/stream`.
+
+Optional start trigger (v0a, issue #44): construct with ``use_start_trigger=True``.
+The index page renders a *splash* with a "Start pursuit" button until the
+user clicks it (``POST /start``). ``wait_for_start(timeout)`` blocks until
+fired — the mission loop calls this before spawning NPCs so you can open
+the page before any world ticks happen.
 """
 
 from __future__ import annotations
@@ -22,9 +28,9 @@ import time
 
 import cv2
 import numpy as np
-from flask import Flask, Response
+from flask import Flask, Response, redirect, url_for
 
-_DEFAULT_HTML = """<!DOCTYPE html>
+_LIVE_HTML = """<!DOCTYPE html>
 <html><head><title>{title}</title>
 <style>
   body {{ margin: 0; background: #111; color: #eee; font-family: monospace; }}
@@ -37,30 +43,62 @@ _DEFAULT_HTML = """<!DOCTYPE html>
 <div id="hud">{hud}</div>
 </body></html>"""
 
+_SPLASH_HTML = """<!DOCTYPE html>
+<html><head><title>{title}</title>
+<style>
+  body {{ margin: 0; min-height: 100vh; background: #111; color: #eee;
+          font-family: monospace; display: flex; align-items: center;
+          justify-content: center; flex-direction: column; gap: 1.5rem; }}
+  h1 {{ font-size: 2rem; margin: 0; color: #7fd; }}
+  p  {{ font-size: 1rem; color: #aaa; max-width: 28rem; text-align: center; }}
+  form button {{ background: #7fd; color: #111; border: 0; padding: 1rem 2rem;
+                 font-size: 1.2rem; border-radius: 0.5rem; cursor: pointer;
+                 font-family: inherit; letter-spacing: 0.05em; }}
+  form button:hover {{ background: #4be; }}
+</style>
+</head><body>
+<h1>{title}</h1>
+<p>{hud}</p>
+<form method="POST" action="/start"><button type="submit">Start pursuit</button></form>
+</body></html>"""
+
 
 class MJPEGServer:
-    """Minimal MJPEG server. One stream, one frame buffer."""
+    """Minimal MJPEG server. One stream, one frame buffer, optional start trigger."""
 
     def __init__(
         self,
         title: str = "SkyCop",
         hud: str = "",
         html: str | None = None,
+        use_start_trigger: bool = False,
     ) -> None:
         self._title = title
         self._hud = hud or title
         self._html = html
         self._frame: np.ndarray | None = None
         self._lock = threading.Lock()
+        self._use_start_trigger = use_start_trigger
+        self._start_event = threading.Event()
+        if not use_start_trigger:
+            # Backwards-compatible: servers without a splash just start already-ready.
+            self._start_event.set()
         self.app = Flask(__name__)
         self._register_routes()
 
     def _register_routes(self) -> None:
         @self.app.route("/")
         def _index() -> str:
+            if self._use_start_trigger and not self._start_event.is_set():
+                return _SPLASH_HTML.format(title=self._title, hud=self._hud)
             if self._html is not None:
                 return self._html
-            return _DEFAULT_HTML.format(title=self._title, hud=self._hud)
+            return _LIVE_HTML.format(title=self._title, hud=self._hud)
+
+        @self.app.route("/start", methods=["POST"])
+        def _start() -> Response:
+            self._start_event.set()
+            return redirect(url_for("_index"))
 
         @self.app.route("/stream")
         def _stream() -> Response:
@@ -68,6 +106,19 @@ class MJPEGServer:
                 self._generate(),
                 mimetype="multipart/x-mixed-replace; boundary=frame",
             )
+
+    def wait_for_start(self, timeout: float | None = None) -> bool:
+        """Block until the Start button is pressed (or ``timeout`` expires).
+
+        Returns ``True`` if started, ``False`` on timeout. When the server
+        was constructed without ``use_start_trigger=True`` the event is
+        pre-set so this returns immediately.
+        """
+        return self._start_event.wait(timeout=timeout)
+
+    @property
+    def started(self) -> bool:
+        return self._start_event.is_set()
 
     def _generate(self):
         while True:

--- a/skycop/main.py
+++ b/skycop/main.py
@@ -21,15 +21,17 @@ log = logging.getLogger("skycop.main")
 
 def main() -> None:
     setup_logging()
-    cfg = load("default", "detector", "training", "tracking", "control", "mission")
+    cfg = load("default", "detector", "training", "tracking", "control", "mission", "suspect")
 
     port = int(cfg.mission.get("mjpeg_port", 5000))
     server = MJPEGServer(
-        title="SkyCop — Mission v0",
-        hud="mission live view · suspect tracking",
+        title="SkyCop — Mission v0a",
+        hud="Open this page, then press Start below. The pursuit begins on click — no ticks happen before you do.",
+        use_start_trigger=True,
     )
     server.start(port=port)
-    log.info("live view: http://localhost:%d", port)
+    log.info("live view + start page: http://localhost:%d", port)
+    log.info("waiting for start click…")
 
     run_mission(cfg, mjpeg_server=server)
 

--- a/skycop/mission.py
+++ b/skycop/mission.py
@@ -29,10 +29,11 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import queue
 import random
 import time
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from pathlib import Path
 
@@ -62,6 +63,14 @@ from skycop.sim import (
     synchronous_mode,
     teardown_pursuit,
 )
+from skycop.sim.suspect_fsm import (
+    FSMConfig,
+    ParkingSubstate,
+    SuspectFSM,
+    SuspectState,
+    TMKnobs,
+)
+from skycop.vendor.carla_agents import GlobalRoutePlanner, LocalPlanner
 
 log = logging.getLogger(__name__)
 
@@ -91,6 +100,10 @@ class MissionResult:
     video_path: str | None
     trace_path: str
     summary_path: str
+    # v0a (issue #44): suspect FSM outcome + per-state metrics.
+    fsm_submission: str | None       # "ai_pass" / "timeout_lose" / None
+    fsm_terminal_state: str          # final FSM state name
+    per_state: dict = field(default_factory=dict)
 
 
 # ── Helpers ────────────────────────────────────────────────────────────
@@ -105,8 +118,128 @@ def _camera_world_matrix(camera: carla.Actor) -> np.ndarray:
     return np.array(camera.get_transform().get_matrix(), dtype=np.float64)
 
 
+# ── FSM plumbing ──────────────────────────────────────────────────────
+
+def _build_fsm(suspect_cfg) -> SuspectFSM:
+    """Assemble a SuspectFSM from the OmegaConf `suspect` subtree."""
+    fsm_sec = suspect_cfg.fsm
+    knobs = suspect_cfg.knobs
+
+    def _knobs(block) -> TMKnobs:
+        return TMKnobs(
+            speed_over_pct=float(block.speed_over_pct),
+            ignore_lights_pct=float(block.ignore_lights_pct),
+            ignore_signs_pct=float(block.ignore_signs_pct),
+            lane_change_pct=float(block.lane_change_pct),
+            follow_dist_m=float(block.follow_dist_m),
+        )
+
+    def _xyz(p) -> tuple[float, float, float]:
+        return (float(p.x), float(p.y), float(p.z))
+
+    cfg = FSMConfig(
+        fleeing_duration_s=float(fsm_sec.fleeing_duration_s),
+        roaming_duration_s=float(fsm_sec.roaming_duration_s),
+        parking_lot_timeout_s=float(fsm_sec.parking_lot_timeout_s),
+        parking_roadside_timeout_s=float(fsm_sec.parking_roadside_timeout_s),
+        parked_confirm_timeout_s=float(fsm_sec.parked_confirm_timeout_s),
+        reach_distance_m=float(fsm_sec.reach_distance_m),
+        reach_speed_mps=float(fsm_sec.reach_speed_mps),
+        ai_consecutive_lock_ticks=int(fsm_sec.ai_consecutive_lock_ticks),
+        fleeing_knobs=_knobs(knobs.fleeing),
+        roaming_knobs=_knobs(knobs.roaming),
+        parking_lots=tuple(_xyz(p) for p in suspect_cfg.parking_lots),
+        roadside_spots=tuple(_xyz(p) for p in suspect_cfg.roadside_spots),
+    )
+    return SuspectFSM(cfg=cfg)
+
+
+def _apply_tm_knobs(
+    tm: carla.TrafficManager,
+    vehicle: carla.Actor,
+    knobs: TMKnobs,
+) -> None:
+    """Write the six TM knobs the FSM emits on state entry."""
+    tm.vehicle_percentage_speed_difference(vehicle, knobs.speed_over_pct)
+    tm.ignore_lights_percentage(vehicle, knobs.ignore_lights_pct)
+    tm.ignore_signs_percentage(vehicle, knobs.ignore_signs_pct)
+    tm.random_left_lanechange_percentage(vehicle, knobs.lane_change_pct)
+    tm.random_right_lanechange_percentage(vehicle, knobs.lane_change_pct)
+    tm.distance_to_leading_vehicle(vehicle, knobs.follow_dist_m)
+
+
+def _build_local_planner(
+    vehicle: carla.Actor,
+    grp: GlobalRoutePlanner,
+    dest_xyz: tuple[float, float, float],
+    target_speed_kmh: float,
+    sampling_resolution_m: float,
+    dt: float,
+) -> LocalPlanner:
+    """Route vehicle→destination and hand off to a fresh LocalPlanner.
+
+    The caller must have already called ``vehicle.set_autopilot(False)``
+    so the TM doesn't fight the planner.
+    """
+    dest_loc = carla.Location(*dest_xyz)
+    route = grp.trace_route(vehicle.get_location(), dest_loc)
+    planner = LocalPlanner(
+        vehicle,
+        opt_dict={
+            "target_speed": target_speed_kmh,
+            "dt": dt,
+            "sampling_radius": sampling_resolution_m,
+        },
+    )
+    planner.set_global_plan(route, stop_waypoint_creation=True)
+    return planner
+
+
+@dataclass
+class _PerStateAccum:
+    """Rolling accumulators so we can report id_accuracy etc. per FSM state."""
+    frames_total: int = 0
+    frames_visible: int = 0
+    frames_id_correct: int = 0
+    frames_in_frame: int = 0
+    distance_samples: list[float] = field(default_factory=list)
+
+    def finalise(self) -> dict:
+        id_acc = (
+            self.frames_id_correct / self.frames_visible
+            if self.frames_visible > 0 else None
+        )
+        in_frame_rate = (
+            self.frames_in_frame / self.frames_total
+            if self.frames_total > 0 else None
+        )
+        if self.distance_samples:
+            d_mean = float(np.mean(self.distance_samples))
+            d_p95 = float(np.percentile(self.distance_samples, 95.0))
+        else:
+            d_mean = d_p95 = None
+        return {
+            "frames_total": self.frames_total,
+            "frames_visible": self.frames_visible,
+            "id_accuracy": round(id_acc, 4) if id_acc is not None else None,
+            "in_frame_rate": round(in_frame_rate, 4) if in_frame_rate is not None else None,
+            "track_distance_mean_m": round(d_mean, 3) if d_mean is not None else None,
+            "track_distance_p95_m": round(d_p95, 3) if d_p95 is not None else None,
+        }
+
+
 def _fmt_score(s: float) -> str:
     return f"{s:.2f}"
+
+
+def _fsm_hud_line(fsm_tick) -> str:
+    """Short HUD string: FSM state + (substate or countdown)."""
+    state = fsm_tick.state.value
+    if fsm_tick.parking_substate is not None:
+        return f"{state}·{fsm_tick.parking_substate.value}"
+    if fsm_tick.countdown_s is not None:
+        return f"{state} {fsm_tick.countdown_s:4.1f}s"
+    return state
 
 
 def _render_mission_overlay(
@@ -118,6 +251,7 @@ def _render_mission_overlay(
     frame_idx: int,
     running_id_accuracy: float | None,
     drone_to_suspect_m: float | None = None,
+    hud_extra: str | None = None,
 ) -> np.ndarray:
     out = frame_bgr.copy()
     h, w = out.shape[:2]
@@ -155,6 +289,9 @@ def _render_mission_overlay(
     if drone_to_suspect_m is not None:
         cv2.putText(out, f"dist {drone_to_suspect_m:5.1f}m", (8, h - 60),
                     cv2.FONT_HERSHEY_SIMPLEX, 0.6, (255, 200, 80), 2, cv2.LINE_AA)
+    if hud_extra:
+        cv2.putText(out, hud_extra, (8, h - 84),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.65, (120, 220, 255), 2, cv2.LINE_AA)
     return out
 
 
@@ -239,6 +376,14 @@ def run_mission(cfg, mjpeg_server: MJPEGServer | None = None) -> MissionResult:
         world = client.load_world(cfg.carla.map)
     world.set_weather(weather_preset(weather_name))
 
+    # Start trigger (v0a): mission blocks here until the user clicks
+    # "Start pursuit" on the MJPEG page (or instantly if the server wasn't
+    # constructed with use_start_trigger=True).
+    if mjpeg_server is not None and not mjpeg_server.started:
+        log.info("mission paused — waiting for /start click on the MJPEG page…")
+        mjpeg_server.wait_for_start()
+        log.info("start received; bringing up the scene")
+
     K = build_camera_matrix(int(cfg.camera.width), int(cfg.camera.height), float(cfg.camera.fov))
     image_size = (int(cfg.camera.height), int(cfg.camera.width))
 
@@ -282,7 +427,7 @@ def run_mission(cfg, mjpeg_server: MJPEGServer | None = None) -> MissionResult:
                 fp16=bool(cfg.training.half),
             )
 
-            log.info("altitude pinned to mission.altitude_m=%.1fm (per D-12)", altitude_m)
+            log.info("altitude pinned to mission.altitude_m=%.1fm (v0a bump — adaptive altitude is issue #45)", altitude_m)
 
             if save_video:
                 fourcc = cv2.VideoWriter_fourcc(*"mp4v")
@@ -339,9 +484,23 @@ def run_mission(cfg, mjpeg_server: MJPEGServer | None = None) -> MissionResult:
             frames_in_frame = 0             # new — in_frame_rate numerator
             distance_samples: list[float] = []
 
-            target_ticks = int(duration_s / dt)
-            log.info("mission v1a: %.1fs / %d ticks / flight Kp=%.2f Kd=%.2f / feedforward=%s",
-                     duration_s, target_ticks, flight_Kp, flight_Kd, ff_enabled)
+            # ── Suspect FSM (v0a, issue #44) ──────────────────────
+            fsm = _build_fsm(cfg.suspect)
+            suspect_controller_cfg = cfg.suspect.controller
+            grp = GlobalRoutePlanner(
+                world.get_map(),
+                float(suspect_controller_cfg.sampling_resolution_m),
+            )
+            local_planner: LocalPlanner | None = None
+            per_state: dict[SuspectState, _PerStateAccum] = {
+                s: _PerStateAccum() for s in SuspectState
+            }
+            fsm_submission: str | None = None
+            fsm_terminal_state: SuspectState = SuspectState.FLEEING
+
+            target_ticks = int(duration_s / dt)   # safety cap; FSM terminal usually exits earlier
+            log.info("mission v0a: fsm + flight PID / safety cap %.1fs / Kp=%.2f Kd=%.2f",
+                     duration_s, flight_Kp, flight_Kd)
 
             trace_fh = open(trace_path, "w", buffering=1)
             t0 = time.perf_counter()
@@ -385,6 +544,7 @@ def run_mission(cfg, mjpeg_server: MJPEGServer | None = None) -> MissionResult:
                     distance_samples.append(drone_to_suspect)
 
                     suspect_visible = gt_bbox is not None
+                    suspect_fully_in_frame = False
                     if suspect_visible:
                         frames_suspect_visible += 1
                         # Fully-in-frame check: project the 8 GT vertices un-clipped
@@ -401,6 +561,7 @@ def run_mission(cfg, mjpeg_server: MJPEGServer | None = None) -> MissionResult:
                                 and vs.min() >= 0 and vs.max() <= image_size[0] - 1
                             ):
                                 frames_in_frame += 1
+                                suspect_fully_in_frame = True
 
                     # Detect + track.
                     tracks = adapter.update(frame_bgr)
@@ -514,14 +675,76 @@ def run_mission(cfg, mjpeg_server: MJPEGServer | None = None) -> MissionResult:
                             pid_y.reset()
                             target_tracker.reset()
 
+                    # ── Suspect FSM step ─────────────────────────────────
+                    suspect_tf_now = suspect.get_transform()
+                    suspect_vel = suspect.get_velocity()
+                    suspect_speed = float(math.hypot(suspect_vel.x, suspect_vel.y))
+                    ai_lock_on_suspect = bool(
+                        suspect_visible
+                        and locked_track_id is not None
+                        and locked_track_id == gt_matched_track_id
+                    )
+                    fsm_tick = fsm.tick(
+                        t=float(tick) * dt,
+                        suspect_xy=(suspect_tf_now.location.x, suspect_tf_now.location.y),
+                        suspect_speed=suspect_speed,
+                        ai_lock_on_suspect=ai_lock_on_suspect,
+                    )
+
+                    # Side-effects requested by the FSM on state entries.
+                    act = fsm_tick.action
+                    if act.apply_tm_knobs is not None:
+                        _apply_tm_knobs(tm, suspect, act.apply_tm_knobs)
+                    if act.set_path_to is not None:
+                        # PARKING entry (trying_lot) OR roadside escalation — both
+                        # rebuild the LocalPlanner. We disable autopilot the first
+                        # time only.
+                        if local_planner is None:
+                            suspect.set_autopilot(False)
+                        local_planner = _build_local_planner(
+                            vehicle=suspect, grp=grp,
+                            dest_xyz=act.set_path_to,
+                            target_speed_kmh=float(suspect_controller_cfg.target_speed_kmh),
+                            sampling_resolution_m=float(suspect_controller_cfg.sampling_resolution_m),
+                            dt=dt,
+                        )
+                        log.info("FSM → PARKING: routing to %s", act.set_path_to)
+                    if act.freeze_physics:
+                        suspect.set_simulate_physics(False)
+                        log.info("FSM → PARKED: physics frozen, confirmation window open")
+
+                    # Drive the suspect during PARKING (off-autopilot); brake during
+                    # park_in_place. In PARKED we've frozen physics; apply a zero-
+                    # control so no residual command lingers.
+                    if fsm_tick.state == SuspectState.PARKING:
+                        if fsm_tick.parking_substate == ParkingSubstate.PARK_IN_PLACE:
+                            suspect.apply_control(carla.VehicleControl(brake=1.0))
+                        elif local_planner is not None:
+                            suspect.apply_control(local_planner.run_step())
+                    elif fsm_tick.state == SuspectState.PARKED:
+                        suspect.apply_control(carla.VehicleControl(brake=1.0))
+
+                    # Per-state metric accumulation — mirrors the aggregate counters.
+                    acc = per_state[fsm_tick.state]
+                    acc.frames_total += 1
+                    if suspect_visible:
+                        acc.frames_visible += 1
+                        if locked_track_id is not None and locked_track_id == gt_matched_track_id:
+                            acc.frames_id_correct += 1
+                        if suspect_fully_in_frame:
+                            acc.frames_in_frame += 1
+                    acc.distance_samples.append(drone_to_suspect)
+
                     # ── Overlay + live push ──────────────────────────────
                     running_id_accuracy = (
                         frames_id_correct / frames_suspect_visible
                         if frames_suspect_visible > 0 else None
                     )
+                    hud_extra = _fsm_hud_line(fsm_tick)
                     overlay = _render_mission_overlay(
                         frame_bgr, gt_bbox, tracks, locked_track_id, track_scores,
                         frames_total, running_id_accuracy, drone_to_suspect,
+                        hud_extra=hud_extra,
                     )
                     if video_writer is not None:
                         video_writer.write(overlay)
@@ -529,17 +752,38 @@ def run_mission(cfg, mjpeg_server: MJPEGServer | None = None) -> MissionResult:
                         mjpeg_server.push(overlay)
 
                     # ── Per-tick trace ───────────────────────────────────
+                    # GT poses logged so we can reconstruct the scene offline
+                    # (e.g. to see where the suspect got stuck vs where the
+                    # drone hovered when the tracker drifted).
                     trace_fh.write(json.dumps({
                         "tick": tick,
+                        "drone_xy": [round(float(drone_pos_world[0]), 2),
+                                     round(float(drone_pos_world[1]), 2)],
+                        "suspect_xy": [round(suspect_tf_now.location.x, 2),
+                                       round(suspect_tf_now.location.y, 2)],
+                        "suspect_speed_mps": round(suspect_speed, 3),
+                        "suspect_yaw_deg": round(float(suspect_tf_now.rotation.yaw), 1),
                         "drone_to_suspect_m": round(drone_to_suspect, 3),
                         "center_offset_px": round(center_offset_px, 1),
                         "velocity_cmd_m_s": round(velocity_cmd_magnitude, 3),
                         "locked_track_id": locked_track_id,
                         "gt_matched_track_id": gt_matched_track_id,
                         "suspect_visible": bool(suspect_visible),
+                        "fsm_state": fsm_tick.state.value,
+                        "fsm_sub": (fsm_tick.parking_substate.value
+                                    if fsm_tick.parking_substate else None),
+                        "fsm_countdown_s": (round(fsm_tick.countdown_s, 2)
+                                            if fsm_tick.countdown_s is not None else None),
                     }) + "\n")
 
                     frames_total += 1
+
+                    fsm_terminal_state = fsm_tick.state
+                    if fsm_tick.terminal:
+                        fsm_submission = fsm_tick.submission
+                        log.info("FSM terminal at tick %d: submission=%s",
+                                 tick, fsm_submission)
+                        break
             finally:
                 trace_fh.close()
 
@@ -572,6 +816,8 @@ def run_mission(cfg, mjpeg_server: MJPEGServer | None = None) -> MissionResult:
                 in_frame_rate,
             )
 
+            per_state_summary = {s.value: per_state[s].finalise() for s in SuspectState}
+
             result = MissionResult(
                 run_id=run_id,
                 duration_s=elapsed,
@@ -592,7 +838,12 @@ def run_mission(cfg, mjpeg_server: MJPEGServer | None = None) -> MissionResult:
                 video_path=str(video_path) if save_video else None,
                 trace_path=str(trace_path),
                 summary_path=str(summary_path),
+                fsm_submission=fsm_submission,
+                fsm_terminal_state=fsm_terminal_state.value,
+                per_state=per_state_summary,
             )
+            log.info("FSM outcome: terminal_state=%s submission=%s",
+                     result.fsm_terminal_state, result.fsm_submission)
 
             with open(summary_path, "w") as f:
                 payload = asdict(result)

--- a/skycop/sim/suspect_fsm.py
+++ b/skycop/sim/suspect_fsm.py
@@ -1,0 +1,369 @@
+"""Suspect FSM — drives the target vehicle through realistic pursuit states.
+
+Pure-logic module; no CARLA imports. Observations (``t``, ``suspect_xy``,
+``suspect_speed``, ``ai_lock_on_suspect``) go in; a ``FSMTick`` with the
+current state, any side-effects the mission loop should perform
+(TM-knob re-apply, ``set_path``, freeze physics), a PARKED-countdown value
+and a submission-event label comes out.
+
+State machine::
+
+    FLEEING ──(after fleeing_duration_s)──► ROAMING
+       │
+    ROAMING ──(after roaming_duration_s)──► PARKING (trying_lot)
+       │
+    PARKING.trying_lot ──(reached)──► PARKED
+            └─(lot_timeout_s)──► PARKING.trying_roadside ──(reached)──► PARKED
+                                     └─(roadside_timeout_s)──► PARKING.park_in_place ──► PARKED
+       │
+    PARKED starts a ``confirm_timeout_s`` countdown
+       │
+    submission("ai_pass") on first K consecutive ticks with ai_lock_on_suspect
+    submission("timeout_lose") if countdown reaches 0 without a pass
+    either submission ⇒ terminal=True
+
+Transition rationale recorded in docs/design.md.
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Literal
+
+
+class SuspectState(str, Enum):
+    FLEEING = "fleeing"
+    ROAMING = "roaming"
+    PARKING = "parking"
+    PARKED = "parked"
+
+
+class ParkingSubstate(str, Enum):
+    TRYING_LOT = "trying_lot"
+    TRYING_ROADSIDE = "trying_roadside"
+    PARK_IN_PLACE = "park_in_place"
+
+
+# ── Configuration ──────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class TMKnobs:
+    """TrafficManager knob values for one FSM state.
+
+    Sign convention matches CARLA's ``vehicle_percentage_speed_difference``:
+    negative = faster than the speed limit, positive = slower. See
+    docs/carla_caveats.md §9.
+    """
+    speed_over_pct: float
+    ignore_lights_pct: float
+    ignore_signs_pct: float
+    lane_change_pct: float
+    follow_dist_m: float
+
+
+@dataclass(frozen=True)
+class FSMConfig:
+    fleeing_duration_s: float
+    roaming_duration_s: float
+    parking_lot_timeout_s: float
+    parking_roadside_timeout_s: float
+    parked_confirm_timeout_s: float
+    reach_distance_m: float
+    reach_speed_mps: float
+    ai_consecutive_lock_ticks: int
+    fleeing_knobs: TMKnobs
+    roaming_knobs: TMKnobs
+    # PARKING runs off-autopilot (custom WaypointFollower controller); no
+    # TM knobs apply. The mission loop handles the disable-autopilot / brake
+    # side-effects when it sees a PARKING state transition.
+    parking_lots: tuple[tuple[float, float, float], ...]      # (x, y, z) waypoints
+    roadside_spots: tuple[tuple[float, float, float], ...]
+
+
+# ── Per-tick I/O ───────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class FSMAction:
+    """Side-effects the mission loop should perform in response to a tick.
+
+    All fields default to "do nothing" so ticks that change no state keep
+    the mission loop quiet. State-entry ticks populate the relevant fields.
+    """
+    apply_tm_knobs: TMKnobs | None = None
+    set_path_to: tuple[float, float, float] | None = None
+    freeze_physics: bool = False
+
+
+SubmissionEvent = Literal["ai_pass", "timeout_lose"]
+
+
+@dataclass(frozen=True)
+class FSMTick:
+    state: SuspectState
+    parking_substate: ParkingSubstate | None
+    action: FSMAction
+    countdown_s: float | None         # seconds remaining in PARKED window
+    submission: SubmissionEvent | None
+    terminal: bool                    # mission ends this tick
+
+
+# ── FSM ────────────────────────────────────────────────────────────────
+
+@dataclass
+class SuspectFSM:
+    cfg: FSMConfig
+    rng: random.Random = field(default_factory=random.Random)
+
+    _state: SuspectState = field(init=False, default=SuspectState.FLEEING)
+    _parking_substate: ParkingSubstate | None = field(init=False, default=None)
+    _state_entered_at: float = field(init=False, default=0.0)
+    _parked_entered_at: float | None = field(init=False, default=None)
+    _ai_lock_streak: int = field(init=False, default=0)
+    _chosen_destination: tuple[float, float, float] | None = field(init=False, default=None)
+    _initial_tick_emitted: bool = field(init=False, default=False)
+
+    # ── Public API ─────────────────────────────────────────────────
+
+    def tick(
+        self,
+        t: float,
+        suspect_xy: tuple[float, float],
+        suspect_speed: float,
+        ai_lock_on_suspect: bool,
+    ) -> FSMTick:
+        """Advance the FSM by one tick. Returns the tick result."""
+        # The first tick emitted also counts as an entry into FLEEING, so the
+        # mission loop applies the initial knobs.
+        entry_action: FSMAction = FSMAction()
+        if not self._initial_tick_emitted:
+            self._state_entered_at = t
+            entry_action = FSMAction(apply_tm_knobs=self.cfg.fleeing_knobs)
+            self._initial_tick_emitted = True
+            return FSMTick(
+                state=SuspectState.FLEEING,
+                parking_substate=None,
+                action=entry_action,
+                countdown_s=None,
+                submission=None,
+                terminal=False,
+            )
+
+        # ── FLEEING ──
+        if self._state == SuspectState.FLEEING:
+            if t - self._state_entered_at >= self.cfg.fleeing_duration_s:
+                return self._enter_roaming(t)
+            return self._plain(SuspectState.FLEEING)
+
+        # ── ROAMING ──
+        if self._state == SuspectState.ROAMING:
+            if t - self._state_entered_at >= self.cfg.roaming_duration_s:
+                return self._enter_parking_trying_lot(t, suspect_xy)
+            return self._plain(SuspectState.ROAMING)
+
+        # ── PARKING ──
+        if self._state == SuspectState.PARKING:
+            return self._tick_parking(t, suspect_xy, suspect_speed)
+
+        # ── PARKED ──
+        if self._state == SuspectState.PARKED:
+            return self._tick_parked(t, ai_lock_on_suspect)
+
+        raise AssertionError(f"unknown state {self._state!r}")
+
+    # ── Internal transitions ───────────────────────────────────────
+
+    def _plain(
+        self,
+        state: SuspectState,
+        substate: ParkingSubstate | None = None,
+        countdown_s: float | None = None,
+    ) -> FSMTick:
+        return FSMTick(
+            state=state,
+            parking_substate=substate,
+            action=FSMAction(),
+            countdown_s=countdown_s,
+            submission=None,
+            terminal=False,
+        )
+
+    def _enter_roaming(self, t: float) -> FSMTick:
+        self._state = SuspectState.ROAMING
+        self._state_entered_at = t
+        return FSMTick(
+            state=SuspectState.ROAMING,
+            parking_substate=None,
+            action=FSMAction(apply_tm_knobs=self.cfg.roaming_knobs),
+            countdown_s=None,
+            submission=None,
+            terminal=False,
+        )
+
+    def _enter_parking_trying_lot(
+        self,
+        t: float,
+        suspect_xy: tuple[float, float],
+    ) -> FSMTick:
+        self._state = SuspectState.PARKING
+        self._parking_substate = ParkingSubstate.TRYING_LOT
+        self._state_entered_at = t
+        dest = self._pick_nearest(suspect_xy, self.cfg.parking_lots)
+        self._chosen_destination = dest
+        return FSMTick(
+            state=SuspectState.PARKING,
+            parking_substate=ParkingSubstate.TRYING_LOT,
+            action=FSMAction(set_path_to=dest),
+            countdown_s=None,
+            submission=None,
+            terminal=False,
+        )
+
+    def _enter_parking_trying_roadside(
+        self,
+        t: float,
+        suspect_xy: tuple[float, float],
+    ) -> FSMTick:
+        self._parking_substate = ParkingSubstate.TRYING_ROADSIDE
+        self._state_entered_at = t
+        dest = self._pick_nearest(suspect_xy, self.cfg.roadside_spots)
+        self._chosen_destination = dest
+        return FSMTick(
+            state=SuspectState.PARKING,
+            parking_substate=ParkingSubstate.TRYING_ROADSIDE,
+            action=FSMAction(set_path_to=dest),
+            countdown_s=None,
+            submission=None,
+            terminal=False,
+        )
+
+    def _enter_park_in_place(self, t: float) -> FSMTick:
+        self._parking_substate = ParkingSubstate.PARK_IN_PLACE
+        self._state_entered_at = t
+        # No action needed — mission loop reads substate == PARK_IN_PLACE
+        # and just applies a brake-only control each tick.
+        return FSMTick(
+            state=SuspectState.PARKING,
+            parking_substate=ParkingSubstate.PARK_IN_PLACE,
+            action=FSMAction(),
+            countdown_s=None,
+            submission=None,
+            terminal=False,
+        )
+
+    def _enter_parked(self, t: float) -> FSMTick:
+        self._state = SuspectState.PARKED
+        self._parking_substate = None
+        self._state_entered_at = t
+        self._parked_entered_at = t
+        self._ai_lock_streak = 0
+        return FSMTick(
+            state=SuspectState.PARKED,
+            parking_substate=None,
+            action=FSMAction(freeze_physics=True),
+            countdown_s=self.cfg.parked_confirm_timeout_s,
+            submission=None,
+            terminal=False,
+        )
+
+    # ── Per-state tick handlers ────────────────────────────────────
+
+    def _tick_parking(
+        self,
+        t: float,
+        suspect_xy: tuple[float, float],
+        suspect_speed: float,
+    ) -> FSMTick:
+        sub = self._parking_substate
+        assert sub is not None  # invariant: PARKING always has a substate
+
+        if sub == ParkingSubstate.PARK_IN_PLACE:
+            # Gentle-brake knobs have been applied; wait for the car to stop.
+            if suspect_speed < self.cfg.reach_speed_mps:
+                return self._enter_parked(t)
+            return self._plain(SuspectState.PARKING, substate=sub)
+
+        # trying_lot or trying_roadside: check for arrival, else timeout-escalate.
+        assert self._chosen_destination is not None
+        dx = suspect_xy[0] - self._chosen_destination[0]
+        dy = suspect_xy[1] - self._chosen_destination[1]
+        dist = (dx * dx + dy * dy) ** 0.5
+        if dist <= self.cfg.reach_distance_m and suspect_speed < self.cfg.reach_speed_mps:
+            return self._enter_parked(t)
+
+        elapsed = t - self._state_entered_at
+        timeout_s = (
+            self.cfg.parking_lot_timeout_s
+            if sub == ParkingSubstate.TRYING_LOT
+            else self.cfg.parking_roadside_timeout_s
+        )
+        if elapsed >= timeout_s:
+            if sub == ParkingSubstate.TRYING_LOT and self.cfg.roadside_spots:
+                return self._enter_parking_trying_roadside(t, suspect_xy)
+            return self._enter_park_in_place(t)
+
+        return self._plain(SuspectState.PARKING, substate=sub)
+
+    def _tick_parked(self, t: float, ai_lock_on_suspect: bool) -> FSMTick:
+        assert self._parked_entered_at is not None
+        elapsed = t - self._parked_entered_at
+        countdown = max(0.0, self.cfg.parked_confirm_timeout_s - elapsed)
+
+        if ai_lock_on_suspect:
+            self._ai_lock_streak += 1
+        else:
+            self._ai_lock_streak = 0
+
+        if self._ai_lock_streak >= self.cfg.ai_consecutive_lock_ticks:
+            return FSMTick(
+                state=SuspectState.PARKED,
+                parking_substate=None,
+                action=FSMAction(),
+                countdown_s=countdown,
+                submission="ai_pass",
+                terminal=True,
+            )
+
+        if countdown <= 0.0:
+            return FSMTick(
+                state=SuspectState.PARKED,
+                parking_substate=None,
+                action=FSMAction(),
+                countdown_s=0.0,
+                submission="timeout_lose",
+                terminal=True,
+            )
+
+        return FSMTick(
+            state=SuspectState.PARKED,
+            parking_substate=None,
+            action=FSMAction(),
+            countdown_s=countdown,
+            submission=None,
+            terminal=False,
+        )
+
+    # ── Helpers ────────────────────────────────────────────────────
+
+    def _pick_nearest(
+        self,
+        xy: tuple[float, float],
+        candidates: tuple[tuple[float, float, float], ...],
+    ) -> tuple[float, float, float] | None:
+        if not candidates:
+            return None
+        return min(
+            candidates,
+            key=lambda p: (p[0] - xy[0]) ** 2 + (p[1] - xy[1]) ** 2,
+        )
+
+    # ── Observability ──────────────────────────────────────────────
+
+    @property
+    def state(self) -> SuspectState:
+        return self._state
+
+    @property
+    def parking_substate(self) -> ParkingSubstate | None:
+        return self._parking_substate

--- a/skycop/vendor/__init__.py
+++ b/skycop/vendor/__init__.py
@@ -1,0 +1,5 @@
+"""Third-party code vendored into SkyCop.
+
+Each subpackage includes a LICENSE file and a note on what was copied
+verbatim vs. patched.
+"""

--- a/skycop/vendor/carla_agents/LICENSE_CARLA
+++ b/skycop/vendor/carla_agents/LICENSE_CARLA
@@ -1,0 +1,39 @@
+The files in this directory are vendored from the CARLA simulator project
+(https://github.com/carla-simulator/carla), specifically a subset of
+PythonAPI/carla/agents. They are used here because the pip-installed
+``carla==0.9.16`` distribution does not ship the ``agents`` module — only
+the full source tarball does.
+
+Vendored files:
+- global_route_planner.py — unchanged upstream logic, only two import paths
+  patched to point at the minimal subset vendored alongside.
+- road_option.py — the RoadOption IntEnum, extracted verbatim from
+  agents/navigation/local_planner.py (avoids pulling the whole LocalPlanner).
+- _misc.py — the ``vector`` helper extracted from agents/tools/misc.py.
+
+Original copyright header (from upstream):
+
+  Copyright (c) 2018-2020 CVC.
+
+  This work is licensed under the terms of the MIT license.
+  For a copy, see <https://opensource.org/licenses/MIT>.
+
+MIT License:
+
+  Permission is hereby granted, free of charge, to any person obtaining a
+  copy of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom the
+  Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included
+  in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+  DEALINGS IN THE SOFTWARE.

--- a/skycop/vendor/carla_agents/__init__.py
+++ b/skycop/vendor/carla_agents/__init__.py
@@ -1,0 +1,30 @@
+"""Vendored CARLA agents subset — just enough to run GlobalRoutePlanner.
+
+Upstream: https://github.com/carla-simulator/carla/tree/master/PythonAPI/carla/agents
+License: MIT (see LICENSE_CARLA in this directory).
+
+Why vendored: ``pip install carla==0.9.16`` does not ship the ``agents``
+module — only the binary/source tarball does. We only need
+``GlobalRoutePlanner`` (graph-search router over the map's waypoint graph)
+to drive the suspect to a chosen parking destination when the FSM enters
+PARKING, because ``TrafficManager.set_path()`` is known-broken in 0.9.13
+onward.
+
+Scope: this subset deliberately skips BasicAgent / BehaviorAgent (depend
+on shapely for obstacle polygons, which we don't need), LocalPlanner
+(uses CARLA's own PID — we drive via our lighter WaypointFollower), and
+the full tools/misc module (only the ``vector`` helper is actually
+needed by the router).
+"""
+
+from skycop.vendor.carla_agents.controller import VehiclePIDController
+from skycop.vendor.carla_agents.global_route_planner import GlobalRoutePlanner
+from skycop.vendor.carla_agents.local_planner import LocalPlanner
+from skycop.vendor.carla_agents.road_option import RoadOption
+
+__all__ = [
+    "GlobalRoutePlanner",
+    "LocalPlanner",
+    "RoadOption",
+    "VehiclePIDController",
+]

--- a/skycop/vendor/carla_agents/_misc.py
+++ b/skycop/vendor/carla_agents/_misc.py
@@ -1,0 +1,42 @@
+"""Minimal subset of CARLA's agents.tools.misc — only the helpers the
+vendored GlobalRoutePlanner + LocalPlanner + VehiclePIDController use.
+
+Upstream: https://github.com/carla-simulator/carla/blob/master/PythonAPI/carla/agents/tools/misc.py
+License: MIT.
+
+We vendor ``vector`` (used by GlobalRoutePlanner), ``get_speed`` (used by
+LocalPlanner + VehiclePIDController), and ``draw_waypoints`` (used by
+LocalPlanner debug-draw). The upstream file also contains
+``is_within_distance`` and a few others that only BasicAgent uses — those
+are intentionally skipped.
+"""
+
+import math
+
+import carla
+import numpy as np
+
+
+def vector(location_1, location_2):
+    """Unit vector from ``location_1`` to ``location_2`` (carla.Location)."""
+    x = location_2.x - location_1.x
+    y = location_2.y - location_1.y
+    z = location_2.z - location_1.z
+    norm = np.linalg.norm([x, y, z]) + np.finfo(float).eps
+    return [x / norm, y / norm, z / norm]
+
+
+def get_speed(vehicle):
+    """Compute the speed of a CARLA vehicle in km/h."""
+    vel = vehicle.get_velocity()
+    return 3.6 * math.sqrt(vel.x ** 2 + vel.y ** 2 + vel.z ** 2)
+
+
+def draw_waypoints(world, waypoints, z=0.5):
+    """Draw a list of waypoints at height ``z`` — useful for debug visuals."""
+    for wpt in waypoints:
+        wpt_t = wpt.transform
+        begin = wpt_t.location + carla.Location(z=z)
+        angle = math.radians(wpt_t.rotation.yaw)
+        end = begin + carla.Location(x=math.cos(angle), y=math.sin(angle))
+        world.debug.draw_arrow(begin, end, arrow_size=0.3, life_time=1.0)

--- a/skycop/vendor/carla_agents/controller.py
+++ b/skycop/vendor/carla_agents/controller.py
@@ -1,0 +1,270 @@
+# Copyright (c) 2018-2020 CVC.
+#
+# This work is licensed under the terms of the MIT license.
+# For a copy, see <https://opensource.org/licenses/MIT>.
+#
+# Vendored into SkyCop from
+# PythonAPI/carla/agents/navigation/controller.py. Only change vs. upstream
+# is the tools.misc import path.
+
+""" This module contains PID controllers to perform lateral and longitudinal control. """
+
+from collections import deque
+import math
+import numpy as np
+import carla
+from skycop.vendor.carla_agents._misc import get_speed
+
+
+class VehiclePIDController():
+    """
+    VehiclePIDController is the combination of two PID controllers
+    (lateral and longitudinal) to perform the
+    low level control a vehicle from client side
+    """
+
+
+    def __init__(self, vehicle, args_lateral, args_longitudinal, offset=0, max_throttle=0.75, max_brake=0.3,
+                 max_steering=0.8):
+        """
+        Constructor method.
+
+        :param vehicle: actor to apply to local planner logic onto
+        :param args_lateral: dictionary of arguments to set the lateral PID controller
+        using the following semantics:
+            K_P -- Proportional term
+            K_D -- Differential term
+            K_I -- Integral term
+        :param args_longitudinal: dictionary of arguments to set the longitudinal
+        PID controller using the following semantics:
+            K_P -- Proportional term
+            K_D -- Differential term
+            K_I -- Integral term
+        :param offset: If different than zero, the vehicle will drive displaced from the center line.
+        Positive values imply a right offset while negative ones mean a left one. Numbers high enough
+        to cause the vehicle to drive through other lanes might break the controller.
+        """
+
+        self.max_brake = max_brake
+        self.max_throt = max_throttle
+        self.max_steer = max_steering
+
+        self._vehicle = vehicle
+        self._world = self._vehicle.get_world()
+        self.past_steering = self._vehicle.get_control().steer
+        self._lon_controller = PIDLongitudinalController(self._vehicle, **args_longitudinal)
+        self._lat_controller = PIDLateralController(self._vehicle, offset, **args_lateral)
+
+    def run_step(self, target_speed, waypoint):
+        """
+        Execute one step of control invoking both lateral and longitudinal
+        PID controllers to reach a target waypoint
+        at a given target_speed.
+
+            :param target_speed: desired vehicle speed
+            :param waypoint: target location encoded as a waypoint
+            :return: distance (in meters) to the waypoint
+        """
+
+        acceleration = self._lon_controller.run_step(target_speed)
+        current_steering = self._lat_controller.run_step(waypoint)
+        control = carla.VehicleControl()
+        if acceleration >= 0.0:
+            control.throttle = min(acceleration, self.max_throt)
+            control.brake = 0.0
+        else:
+            control.throttle = 0.0
+            control.brake = min(abs(acceleration), self.max_brake)
+
+        # Steering regulation: changes cannot happen abruptly, can't steer too much.
+
+        if current_steering > self.past_steering + 0.1:
+            current_steering = self.past_steering + 0.1
+        elif current_steering < self.past_steering - 0.1:
+            current_steering = self.past_steering - 0.1
+
+        if current_steering >= 0:
+            steering = min(self.max_steer, current_steering)
+        else:
+            steering = max(-self.max_steer, current_steering)
+
+        control.steer = steering
+        control.hand_brake = False
+        control.manual_gear_shift = False
+        self.past_steering = steering
+
+        return control
+
+
+    def change_longitudinal_PID(self, args_longitudinal):
+        """Changes the parameters of the PIDLongitudinalController"""
+        self._lon_controller.change_parameters(**args_longitudinal)
+
+    def change_lateral_PID(self, args_lateral):
+        """Changes the parameters of the PIDLateralController"""
+        self._lat_controller.change_parameters(**args_lateral)
+
+    def set_offset(self, offset):
+        """Changes the offset"""
+        self._lat_controller.set_offset(offset)
+
+
+class PIDLongitudinalController():
+    """
+    PIDLongitudinalController implements longitudinal control using a PID.
+    """
+
+    def __init__(self, vehicle, K_P=1.0, K_I=0.0, K_D=0.0, dt=0.03):
+        """
+        Constructor method.
+
+            :param vehicle: actor to apply to local planner logic onto
+            :param K_P: Proportional term
+            :param K_D: Differential term
+            :param K_I: Integral term
+            :param dt: time differential in seconds
+        """
+        self._vehicle = vehicle
+        self._k_p = K_P
+        self._k_i = K_I
+        self._k_d = K_D
+        self._dt = dt
+        self._error_buffer = deque(maxlen=10)
+
+    def run_step(self, target_speed, debug=False):
+        """
+        Execute one step of longitudinal control to reach a given target speed.
+
+            :param target_speed: target speed in Km/h
+            :param debug: boolean for debugging
+            :return: throttle control
+        """
+        current_speed = get_speed(self._vehicle)
+
+        if debug:
+            print('Current speed = {}'.format(current_speed))
+
+        return self._pid_control(target_speed, current_speed)
+
+    def _pid_control(self, target_speed, current_speed):
+        """
+        Estimate the throttle/brake of the vehicle based on the PID equations
+
+            :param target_speed:  target speed in Km/h
+            :param current_speed: current speed of the vehicle in Km/h
+            :return: throttle/brake control
+        """
+
+        error = target_speed - current_speed
+        self._error_buffer.append(error)
+
+        if len(self._error_buffer) >= 2:
+            _de = (self._error_buffer[-1] - self._error_buffer[-2]) / self._dt
+            _ie = sum(self._error_buffer) * self._dt
+        else:
+            _de = 0.0
+            _ie = 0.0
+
+        return np.clip((self._k_p * error) + (self._k_d * _de) + (self._k_i * _ie), -1.0, 1.0)
+
+    def change_parameters(self, K_P, K_I, K_D, dt):
+        """Changes the PID parameters"""
+        self._k_p = K_P
+        self._k_i = K_I
+        self._k_d = K_D
+        self._dt = dt
+
+
+class PIDLateralController():
+    """
+    PIDLateralController implements lateral control using a PID.
+    """
+
+    def __init__(self, vehicle, offset=0, K_P=1.0, K_I=0.0, K_D=0.0, dt=0.03):
+        """
+        Constructor method.
+
+            :param vehicle: actor to apply to local planner logic onto
+            :param offset: distance to the center line. If might cause issues if the value
+                is large enough to make the vehicle invade other lanes.
+            :param K_P: Proportional term
+            :param K_D: Differential term
+            :param K_I: Integral term
+            :param dt: time differential in seconds
+        """
+        self._vehicle = vehicle
+        self._k_p = K_P
+        self._k_i = K_I
+        self._k_d = K_D
+        self._dt = dt
+        self._offset = offset
+        self._e_buffer = deque(maxlen=10)
+
+    def run_step(self, waypoint):
+        """
+        Execute one step of lateral control to steer
+        the vehicle towards a certain waypoin.
+
+            :param waypoint: target waypoint
+            :return: steering control in the range [-1, 1] where:
+            -1 maximum steering to left
+            +1 maximum steering to right
+        """
+        return self._pid_control(waypoint, self._vehicle.get_transform())
+
+    def set_offset(self, offset):
+        """Changes the offset"""
+        self._offset = offset
+
+    def _pid_control(self, waypoint, vehicle_transform):
+        """
+        Estimate the steering angle of the vehicle based on the PID equations
+
+            :param waypoint: target waypoint
+            :param vehicle_transform: current transform of the vehicle
+            :return: steering control in the range [-1, 1]
+        """
+        # Get the ego's location and forward vector
+        ego_loc = vehicle_transform.location
+        v_vec = vehicle_transform.get_forward_vector()
+        v_vec = np.array([v_vec.x, v_vec.y, 0.0])
+
+        # Get the vector vehicle-target_wp
+        if self._offset != 0:
+            # Displace the wp to the side
+            w_tran = waypoint.transform
+            r_vec = w_tran.get_right_vector()
+            w_loc = w_tran.location + carla.Location(x=self._offset*r_vec.x,
+                                                         y=self._offset*r_vec.y)
+        else:
+            w_loc = waypoint.transform.location
+
+        w_vec = np.array([w_loc.x - ego_loc.x,
+                          w_loc.y - ego_loc.y,
+                          0.0])
+
+        wv_linalg = np.linalg.norm(w_vec) * np.linalg.norm(v_vec)
+        if wv_linalg == 0:
+            _dot = 1
+        else:
+            _dot = math.acos(np.clip(np.dot(w_vec, v_vec) / (wv_linalg), -1.0, 1.0))
+        _cross = np.cross(v_vec, w_vec)
+        if _cross[2] < 0:
+            _dot *= -1.0
+
+        self._e_buffer.append(_dot)
+        if len(self._e_buffer) >= 2:
+            _de = (self._e_buffer[-1] - self._e_buffer[-2]) / self._dt
+            _ie = sum(self._e_buffer) * self._dt
+        else:
+            _de = 0.0
+            _ie = 0.0
+
+        return np.clip((self._k_p * _dot) + (self._k_d * _de) + (self._k_i * _ie), -1.0, 1.0)
+
+    def change_parameters(self, K_P, K_I, K_D, dt):
+        """Changes the PID parameters"""
+        self._k_p = K_P
+        self._k_i = K_I
+        self._k_d = K_D
+        self._dt = dt

--- a/skycop/vendor/carla_agents/global_route_planner.py
+++ b/skycop/vendor/carla_agents/global_route_planner.py
@@ -1,0 +1,404 @@
+# Copyright (c) 2018-2020 CVC.
+#
+# This work is licensed under the terms of the MIT license.
+# For a copy, see <https://opensource.org/licenses/MIT>.
+#
+# Vendored into SkyCop: upstream path was
+# PythonAPI/carla/agents/navigation/global_route_planner.py. The only change
+# vs. upstream is the two import lines below — they now point at vendored
+# copies of RoadOption (agents.navigation.local_planner) and vector
+# (agents.tools.misc). All routing logic is unchanged.
+
+
+"""
+This module provides GlobalRoutePlanner implementation.
+"""
+
+import math
+import numpy as np
+import networkx as nx
+
+import carla
+from skycop.vendor.carla_agents.road_option import RoadOption
+from skycop.vendor.carla_agents._misc import vector
+
+class GlobalRoutePlanner(object):
+    """
+    This class provides a very high level route plan.
+    """
+
+    def __init__(self, wmap, sampling_resolution):
+        self._sampling_resolution = sampling_resolution
+        self._wmap = wmap
+        self._topology = None
+        self._graph = None
+        self._id_map = None
+        self._road_id_to_edge = None
+
+        self._intersection_end_node = -1
+        self._previous_decision = RoadOption.VOID
+
+        # Build the graph
+        self._build_topology()
+        self._build_graph()
+        self._find_loose_ends()
+        self._lane_change_link()
+
+    def trace_route(self, origin, destination):
+        """
+        This method returns list of (carla.Waypoint, RoadOption)
+        from origin to destination
+        """
+        route_trace = []
+        route = self._path_search(origin, destination)
+        current_waypoint = self._wmap.get_waypoint(origin)
+        destination_waypoint = self._wmap.get_waypoint(destination)
+
+        for i in range(len(route) - 1):
+            road_option = self._turn_decision(i, route)
+            edge = self._graph.edges[route[i], route[i+1]]
+            path = []
+
+            if edge['type'] != RoadOption.LANEFOLLOW and edge['type'] != RoadOption.VOID:
+                route_trace.append((current_waypoint, road_option))
+                exit_wp = edge['exit_waypoint']
+                n1, n2 = self._road_id_to_edge[exit_wp.road_id][exit_wp.section_id][exit_wp.lane_id]
+                next_edge = self._graph.edges[n1, n2]
+                if next_edge['path']:
+                    closest_index = self._find_closest_in_list(current_waypoint, next_edge['path'])
+                    closest_index = min(len(next_edge['path'])-1, closest_index+5)
+                    current_waypoint = next_edge['path'][closest_index]
+                else:
+                    current_waypoint = next_edge['exit_waypoint']
+                route_trace.append((current_waypoint, road_option))
+
+            else:
+                path = path + [edge['entry_waypoint']] + edge['path'] + [edge['exit_waypoint']]
+                closest_index = self._find_closest_in_list(current_waypoint, path)
+                for waypoint in path[closest_index:]:
+                    current_waypoint = waypoint
+                    route_trace.append((current_waypoint, road_option))
+                    if len(route)-i <= 2 and waypoint.transform.location.distance(destination) < 2*self._sampling_resolution:
+                        break
+                    elif len(route)-i <= 2 and current_waypoint.road_id == destination_waypoint.road_id and current_waypoint.section_id == destination_waypoint.section_id and current_waypoint.lane_id == destination_waypoint.lane_id:
+                        destination_index = self._find_closest_in_list(destination_waypoint, path)
+                        if closest_index > destination_index:
+                            break
+
+        return route_trace
+
+    def _build_topology(self):
+        """
+        This function retrieves topology from the server as a list of
+        road segments as pairs of waypoint objects, and processes the
+        topology into a list of dictionary objects with the following attributes
+
+        - entry (carla.Waypoint): waypoint of entry point of road segment
+        - entryxyz (tuple): (x,y,z) of entry point of road segment
+        - exit (carla.Waypoint): waypoint of exit point of road segment
+        - exitxyz (tuple): (x,y,z) of exit point of road segment
+        - path (list of carla.Waypoint):  list of waypoints between entry to exit, separated by the resolution
+        """
+        self._topology = []
+        # Retrieving waypoints to construct a detailed topology
+        for segment in self._wmap.get_topology():
+            wp1, wp2 = segment[0], segment[1]
+            l1, l2 = wp1.transform.location, wp2.transform.location
+            # Rounding off to avoid floating point imprecision
+            x1, y1, z1, x2, y2, z2 = np.round([l1.x, l1.y, l1.z, l2.x, l2.y, l2.z], 0)
+            wp1.transform.location, wp2.transform.location = l1, l2
+            seg_dict = dict()
+            seg_dict['entry'], seg_dict['exit'] = wp1, wp2
+            seg_dict['entryxyz'], seg_dict['exitxyz'] = (x1, y1, z1), (x2, y2, z2)
+            seg_dict['path'] = []
+            endloc = wp2.transform.location
+            if wp1.transform.location.distance(endloc) > self._sampling_resolution:
+                w = wp1.next(self._sampling_resolution)[0]
+                while w.transform.location.distance(endloc) > self._sampling_resolution:
+                    seg_dict['path'].append(w)
+                    next_ws = w.next(self._sampling_resolution)
+                    if len(next_ws) == 0:
+                        break
+                    w = next_ws[0]
+            else:
+                next_wps = wp1.next(self._sampling_resolution)
+                if len(next_wps) == 0:
+                    continue
+                seg_dict['path'].append(next_wps[0])
+            self._topology.append(seg_dict)
+
+    def _build_graph(self):
+        """
+        This function builds a networkx graph representation of topology, creating several class attributes:
+        - graph (networkx.DiGraph): networkx graph representing the world map, with:
+            Node properties:
+                vertex: (x,y,z) position in world map
+            Edge properties:
+                entry_vector: unit vector along tangent at entry point
+                exit_vector: unit vector along tangent at exit point
+                net_vector: unit vector of the chord from entry to exit
+                intersection: boolean indicating if the edge belongs to an  intersection
+        - id_map (dictionary): mapping from (x,y,z) to node id
+        - road_id_to_edge (dictionary): map from road id to edge in the graph
+        """
+
+        self._graph = nx.DiGraph()
+        self._id_map = dict()  # Map with structure {(x,y,z): id, ... }
+        self._road_id_to_edge = dict()  # Map with structure {road_id: {lane_id: edge, ... }, ... }
+
+        for segment in self._topology:
+            entry_xyz, exit_xyz = segment['entryxyz'], segment['exitxyz']
+            path = segment['path']
+            entry_wp, exit_wp = segment['entry'], segment['exit']
+            intersection = entry_wp.is_junction
+            road_id, section_id, lane_id = entry_wp.road_id, entry_wp.section_id, entry_wp.lane_id
+
+            for vertex in entry_xyz, exit_xyz:
+                # Adding unique nodes and populating id_map
+                if vertex not in self._id_map:
+                    new_id = len(self._id_map)
+                    self._id_map[vertex] = new_id
+                    self._graph.add_node(new_id, vertex=vertex)
+            n1 = self._id_map[entry_xyz]
+            n2 = self._id_map[exit_xyz]
+            if road_id not in self._road_id_to_edge:
+                self._road_id_to_edge[road_id] = dict()
+            if section_id not in self._road_id_to_edge[road_id]:
+                self._road_id_to_edge[road_id][section_id] = dict()
+            self._road_id_to_edge[road_id][section_id][lane_id] = (n1, n2)
+
+            entry_carla_vector = entry_wp.transform.rotation.get_forward_vector()
+            exit_carla_vector = exit_wp.transform.rotation.get_forward_vector()
+
+            # Adding edge with attributes
+            self._graph.add_edge(
+                n1, n2,
+                length=len(path) + 1, path=path,
+                entry_waypoint=entry_wp, exit_waypoint=exit_wp,
+                entry_vector=np.array(
+                    [entry_carla_vector.x, entry_carla_vector.y, entry_carla_vector.z]),
+                exit_vector=np.array(
+                    [exit_carla_vector.x, exit_carla_vector.y, exit_carla_vector.z]),
+                net_vector=vector(entry_wp.transform.location, exit_wp.transform.location),
+                intersection=intersection, type=RoadOption.LANEFOLLOW)
+
+    def _find_loose_ends(self):
+        """
+        This method finds road segments that have an unconnected end, and
+        adds them to the internal graph representation
+        """
+        count_loose_ends = 0
+        hop_resolution = self._sampling_resolution
+        for segment in self._topology:
+            end_wp = segment['exit']
+            exit_xyz = segment['exitxyz']
+            road_id, section_id, lane_id = end_wp.road_id, end_wp.section_id, end_wp.lane_id
+            if road_id in self._road_id_to_edge \
+                    and section_id in self._road_id_to_edge[road_id] \
+                    and lane_id in self._road_id_to_edge[road_id][section_id]:
+                pass
+            else:
+                count_loose_ends += 1
+                if road_id not in self._road_id_to_edge:
+                    self._road_id_to_edge[road_id] = dict()
+                if section_id not in self._road_id_to_edge[road_id]:
+                    self._road_id_to_edge[road_id][section_id] = dict()
+                n1 = self._id_map[exit_xyz]
+                n2 = -1*count_loose_ends
+                self._road_id_to_edge[road_id][section_id][lane_id] = (n1, n2)
+                next_wp = end_wp.next(hop_resolution)
+                path = []
+                while next_wp is not None and next_wp \
+                        and next_wp[0].road_id == road_id \
+                        and next_wp[0].section_id == section_id \
+                        and next_wp[0].lane_id == lane_id:
+                    path.append(next_wp[0])
+                    next_wp = next_wp[0].next(hop_resolution)
+                if path:
+                    n2_xyz = (path[-1].transform.location.x,
+                              path[-1].transform.location.y,
+                              path[-1].transform.location.z)
+                    self._graph.add_node(n2, vertex=n2_xyz)
+                    self._graph.add_edge(
+                        n1, n2,
+                        length=len(path) + 1, path=path,
+                        entry_waypoint=end_wp, exit_waypoint=path[-1],
+                        entry_vector=None, exit_vector=None, net_vector=None,
+                        intersection=end_wp.is_junction, type=RoadOption.LANEFOLLOW)
+
+    def _lane_change_link(self):
+        """
+        This method places zero cost links in the topology graph
+        representing availability of lane changes.
+        """
+
+        for segment in self._topology:
+            left_found, right_found = False, False
+
+            for waypoint in segment['path']:
+                if not segment['entry'].is_junction:
+                    next_waypoint, next_road_option, next_segment = None, None, None
+
+                    if waypoint.right_lane_marking and waypoint.right_lane_marking.lane_change & carla.LaneChange.Right and not right_found:
+                        next_waypoint = waypoint.get_right_lane()
+                        if next_waypoint is not None \
+                                and next_waypoint.lane_type == carla.LaneType.Driving \
+                                and waypoint.road_id == next_waypoint.road_id:
+                            next_road_option = RoadOption.CHANGELANERIGHT
+                            next_segment = self._localize(next_waypoint.transform.location)
+                            if next_segment is not None:
+                                self._graph.add_edge(
+                                    self._id_map[segment['entryxyz']], next_segment[0], entry_waypoint=waypoint,
+                                    exit_waypoint=next_waypoint, intersection=False, exit_vector=None,
+                                    path=[], length=0, type=next_road_option, change_waypoint=next_waypoint)
+                                right_found = True
+                    if waypoint.left_lane_marking and waypoint.left_lane_marking.lane_change & carla.LaneChange.Left and not left_found:
+                        next_waypoint = waypoint.get_left_lane()
+                        if next_waypoint is not None \
+                                and next_waypoint.lane_type == carla.LaneType.Driving \
+                                and waypoint.road_id == next_waypoint.road_id:
+                            next_road_option = RoadOption.CHANGELANELEFT
+                            next_segment = self._localize(next_waypoint.transform.location)
+                            if next_segment is not None:
+                                self._graph.add_edge(
+                                    self._id_map[segment['entryxyz']], next_segment[0], entry_waypoint=waypoint,
+                                    exit_waypoint=next_waypoint, intersection=False, exit_vector=None,
+                                    path=[], length=0, type=next_road_option, change_waypoint=next_waypoint)
+                                left_found = True
+                if left_found and right_found:
+                    break
+
+    def _localize(self, location):
+        """
+        This function finds the road segment that a given location
+        is part of, returning the edge it belongs to
+        """
+        waypoint = self._wmap.get_waypoint(location)
+        edge = None
+        try:
+            edge = self._road_id_to_edge[waypoint.road_id][waypoint.section_id][waypoint.lane_id]
+        except KeyError:
+            pass
+        return edge
+
+    def _distance_heuristic(self, n1, n2):
+        """
+        Distance heuristic calculator for path searching
+        in self._graph
+        """
+        l1 = np.array(self._graph.nodes[n1]['vertex'])
+        l2 = np.array(self._graph.nodes[n2]['vertex'])
+        return np.linalg.norm(l1-l2)
+
+    def _path_search(self, origin, destination):
+        """
+        This function finds the shortest path connecting origin and destination
+        using A* search with distance heuristic.
+        origin      :   carla.Location object of start position
+        destination :   carla.Location object of of end position
+        return      :   path as list of node ids (as int) of the graph self._graph
+        connecting origin and destination
+        """
+        start, end = self._localize(origin), self._localize(destination)
+
+        route = nx.astar_path(
+            self._graph, source=start[0], target=end[0],
+            heuristic=self._distance_heuristic, weight='length')
+        route.append(end[1])
+        return route
+
+    def _successive_last_intersection_edge(self, index, route):
+        """
+        This method returns the last successive intersection edge
+        from a starting index on the route.
+        This helps moving past tiny intersection edges to calculate
+        proper turn decisions.
+        """
+
+        last_intersection_edge = None
+        last_node = None
+        for node1, node2 in [(route[i], route[i+1]) for i in range(index, len(route)-1)]:
+            candidate_edge = self._graph.edges[node1, node2]
+            if node1 == route[index]:
+                last_intersection_edge = candidate_edge
+            if candidate_edge['type'] == RoadOption.LANEFOLLOW and candidate_edge['intersection']:
+                last_intersection_edge = candidate_edge
+                last_node = node2
+            else:
+                break
+
+        return last_node, last_intersection_edge
+
+    def _turn_decision(self, index, route, threshold=math.radians(35)):
+        """
+        This method returns the turn decision (RoadOption) for pair of edges
+        around current index of route list
+        """
+
+        decision = None
+        previous_node = route[index-1]
+        current_node = route[index]
+        next_node = route[index+1]
+        next_edge = self._graph.edges[current_node, next_node]
+        if index > 0:
+            if self._previous_decision != RoadOption.VOID \
+                    and self._intersection_end_node > 0 \
+                    and self._intersection_end_node != previous_node \
+                    and next_edge['type'] == RoadOption.LANEFOLLOW \
+                    and next_edge['intersection']:
+                decision = self._previous_decision
+            else:
+                self._intersection_end_node = -1
+                current_edge = self._graph.edges[previous_node, current_node]
+                calculate_turn = current_edge['type'] == RoadOption.LANEFOLLOW and not current_edge[
+                    'intersection'] and next_edge['type'] == RoadOption.LANEFOLLOW and next_edge['intersection']
+                if calculate_turn:
+                    last_node, tail_edge = self._successive_last_intersection_edge(index, route)
+                    self._intersection_end_node = last_node
+                    if tail_edge is not None:
+                        next_edge = tail_edge
+                    cv, nv = current_edge['exit_vector'], next_edge['exit_vector']
+                    if cv is None or nv is None:
+                        return next_edge['type']
+                    cross_list = []
+                    for neighbor in self._graph.successors(current_node):
+                        select_edge = self._graph.edges[current_node, neighbor]
+                        if select_edge['type'] == RoadOption.LANEFOLLOW:
+                            if neighbor != route[index+1]:
+                                sv = select_edge['net_vector']
+                                cross_list.append(np.cross(cv, sv)[2])
+                    next_cross = np.cross(cv, nv)[2]
+                    deviation = math.acos(np.clip(
+                        np.dot(cv, nv)/(np.linalg.norm(cv)*np.linalg.norm(nv)), -1.0, 1.0))
+                    if not cross_list:
+                        cross_list.append(0)
+                    if deviation < threshold:
+                        decision = RoadOption.STRAIGHT
+                    elif cross_list and next_cross < min(cross_list):
+                        decision = RoadOption.LEFT
+                    elif cross_list and next_cross > max(cross_list):
+                        decision = RoadOption.RIGHT
+                    elif next_cross < 0:
+                        decision = RoadOption.LEFT
+                    elif next_cross > 0:
+                        decision = RoadOption.RIGHT
+                else:
+                    decision = next_edge['type']
+
+        else:
+            decision = next_edge['type']
+
+        self._previous_decision = decision
+        return decision
+
+    def _find_closest_in_list(self, current_waypoint, waypoint_list):
+        min_distance = float('inf')
+        closest_index = -1
+        for i, waypoint in enumerate(waypoint_list):
+            distance = waypoint.transform.location.distance(
+                current_waypoint.transform.location)
+            if distance < min_distance:
+                min_distance = distance
+                closest_index = i
+
+        return closest_index

--- a/skycop/vendor/carla_agents/local_planner.py
+++ b/skycop/vendor/carla_agents/local_planner.py
@@ -1,0 +1,346 @@
+# Copyright (c) 2018-2020 CVC.
+#
+# This work is licensed under the terms of the MIT license.
+# For a copy, see <https://opensource.org/licenses/MIT>.
+#
+# Vendored into SkyCop from
+# PythonAPI/carla/agents/navigation/local_planner.py. Changes vs. upstream:
+#   - controller + tools.misc import paths point at vendored modules.
+#   - The RoadOption IntEnum is imported from our standalone road_option.py
+#     (rather than redefined here) so it matches GlobalRoutePlanner's copy.
+
+""" This module contains a local planner to perform low-level waypoint following based on PID controllers. """
+
+from collections import deque
+import random
+
+import carla
+from skycop.vendor.carla_agents.controller import VehiclePIDController
+from skycop.vendor.carla_agents._misc import draw_waypoints, get_speed
+# RoadOption lives in its own module so GlobalRoutePlanner and LocalPlanner
+# share the same IntEnum (otherwise they'd each define their own copy).
+from skycop.vendor.carla_agents.road_option import RoadOption  # noqa: F401
+
+
+class LocalPlanner(object):
+    """
+    LocalPlanner implements the basic behavior of following a
+    trajectory of waypoints that is generated on-the-fly.
+
+    The low-level motion of the vehicle is computed by using two PID controllers,
+    one is used for the lateral control and the other for the longitudinal control (cruise speed).
+
+    When multiple paths are available (intersections) this local planner makes a random choice,
+    unless a given global plan has already been specified.
+    """
+
+    def __init__(self, vehicle, opt_dict={}, map_inst=None):
+        """
+        :param vehicle: actor to apply to local planner logic onto
+        :param opt_dict: dictionary of arguments with different parameters:
+            dt: time between simulation steps
+            target_speed: desired cruise speed in Km/h
+            sampling_radius: distance between the waypoints part of the plan
+            lateral_control_dict: values of the lateral PID controller
+            longitudinal_control_dict: values of the longitudinal PID controller
+            max_throttle: maximum throttle applied to the vehicle
+            max_brake: maximum brake applied to the vehicle
+            max_steering: maximum steering applied to the vehicle
+            offset: distance between the route waypoints and the center of the lane
+        :param map_inst: carla.Map instance to avoid the expensive call of getting it.
+        """
+        self._vehicle = vehicle
+        self._world = self._vehicle.get_world()
+        if map_inst:
+            if isinstance(map_inst, carla.Map):
+                self._map = map_inst
+            else:
+                print("Warning: Ignoring the given map as it is not a 'carla.Map'")
+                self._map = self._world.get_map()
+        else:
+            self._map = self._world.get_map()
+
+        self._vehicle_controller = None
+        self.target_waypoint = None
+        self.target_road_option = None
+
+        self._waypoints_queue = deque(maxlen=10000)
+        self._min_waypoint_queue_length = 100
+        self._stop_waypoint_creation = False
+
+        # Base parameters
+        self._dt = 1.0 / 20.0
+        self._target_speed = 20.0  # Km/h
+        self._sampling_radius = 2.0
+        self._args_lateral_dict = {'K_P': 1.95, 'K_I': 0.05, 'K_D': 0.2, 'dt': self._dt}
+        self._args_longitudinal_dict = {'K_P': 1.0, 'K_I': 0.05, 'K_D': 0, 'dt': self._dt}
+        self._max_throt = 0.75
+        self._max_brake = 0.3
+        self._max_steer = 0.8
+        self._offset = 0
+        self._base_min_distance = 3.0
+        self._distance_ratio = 0.5
+        self._follow_speed_limits = False
+
+        # Overload parameters
+        if opt_dict:
+            if 'dt' in opt_dict:
+                self._dt = opt_dict['dt']
+            if 'target_speed' in opt_dict:
+                self._target_speed = opt_dict['target_speed']
+            if 'sampling_radius' in opt_dict:
+                self._sampling_radius = opt_dict['sampling_radius']
+            if 'lateral_control_dict' in opt_dict:
+                self._args_lateral_dict = opt_dict['lateral_control_dict']
+            if 'longitudinal_control_dict' in opt_dict:
+                self._args_longitudinal_dict = opt_dict['longitudinal_control_dict']
+            if 'max_throttle' in opt_dict:
+                self._max_throt = opt_dict['max_throttle']
+            if 'max_brake' in opt_dict:
+                self._max_brake = opt_dict['max_brake']
+            if 'max_steering' in opt_dict:
+                self._max_steer = opt_dict['max_steering']
+            if 'offset' in opt_dict:
+                self._offset = opt_dict['offset']
+            if 'base_min_distance' in opt_dict:
+                self._base_min_distance = opt_dict['base_min_distance']
+            if 'distance_ratio' in opt_dict:
+                self._distance_ratio = opt_dict['distance_ratio']
+            if 'follow_speed_limits' in opt_dict:
+                self._follow_speed_limits = opt_dict['follow_speed_limits']
+
+        # initializing controller
+        self._init_controller()
+
+    def reset_vehicle(self):
+        """Reset the ego-vehicle"""
+        self._vehicle = None
+
+    def _init_controller(self):
+        """Controller initialization"""
+        self._vehicle_controller = VehiclePIDController(self._vehicle,
+                                                        args_lateral=self._args_lateral_dict,
+                                                        args_longitudinal=self._args_longitudinal_dict,
+                                                        offset=self._offset,
+                                                        max_throttle=self._max_throt,
+                                                        max_brake=self._max_brake,
+                                                        max_steering=self._max_steer)
+
+        # Compute the current vehicle waypoint
+        current_waypoint = self._map.get_waypoint(self._vehicle.get_location())
+        self.target_waypoint, self.target_road_option = (current_waypoint, RoadOption.LANEFOLLOW)
+        self._waypoints_queue.append((self.target_waypoint, self.target_road_option))
+
+    def set_speed(self, speed):
+        """
+        Changes the target speed
+
+        :param speed: new target speed in Km/h
+        :return:
+        """
+        if self._follow_speed_limits:
+            print("WARNING: The max speed is currently set to follow the speed limits. "
+                  "Use 'follow_speed_limits' to deactivate this")
+        self._target_speed = speed
+
+    def follow_speed_limits(self, value=True):
+        """
+        Activates a flag that makes the max speed dynamically vary according to the spped limits
+
+        :param value: bool
+        :return:
+        """
+        self._follow_speed_limits = value
+
+    def _compute_next_waypoints(self, k=1):
+        """
+        Add new waypoints to the trajectory queue.
+
+        :param k: how many waypoints to compute
+        :return:
+        """
+        # check we do not overflow the queue
+        available_entries = self._waypoints_queue.maxlen - len(self._waypoints_queue)
+        k = min(available_entries, k)
+
+        for _ in range(k):
+            last_waypoint = self._waypoints_queue[-1][0]
+            next_waypoints = list(last_waypoint.next(self._sampling_radius))
+
+            if len(next_waypoints) == 0:
+                break
+            elif len(next_waypoints) == 1:
+                # only one option available ==> lanefollowing
+                next_waypoint = next_waypoints[0]
+                road_option = RoadOption.LANEFOLLOW
+            else:
+                # random choice between the possible options
+                road_options_list = _retrieve_options(
+                    next_waypoints, last_waypoint)
+                road_option = random.choice(road_options_list)
+                next_waypoint = next_waypoints[road_options_list.index(
+                    road_option)]
+
+            self._waypoints_queue.append((next_waypoint, road_option))
+
+    def set_global_plan(self, current_plan, stop_waypoint_creation=True, clean_queue=True):
+        """
+        Adds a new plan to the local planner. A plan must be a list of [carla.Waypoint, RoadOption] pairs
+        The 'clean_queue` parameter erases the previous plan if True, otherwise, it adds it to the old one
+        The 'stop_waypoint_creation' flag stops the automatic creation of random waypoints
+
+        :param current_plan: list of (carla.Waypoint, RoadOption)
+        :param stop_waypoint_creation: bool
+        :param clean_queue: bool
+        :return:
+        """
+        if clean_queue:
+            self._waypoints_queue.clear()
+
+        # Remake the waypoints queue if the new plan has a higher length than the queue
+        new_plan_length = len(current_plan) + len(self._waypoints_queue)
+        if new_plan_length > self._waypoints_queue.maxlen:
+            new_waypoint_queue = deque(maxlen=new_plan_length)
+            for wp in self._waypoints_queue:
+                new_waypoint_queue.append(wp)
+            self._waypoints_queue = new_waypoint_queue
+
+        for elem in current_plan:
+            self._waypoints_queue.append(elem)
+
+        self._stop_waypoint_creation = stop_waypoint_creation
+
+    def set_offset(self, offset):
+        """Sets an offset for the vehicle"""
+        self._vehicle_controller.set_offset(offset)
+
+    def run_step(self, debug=False):
+        """
+        Execute one step of local planning which involves running the longitudinal and lateral PID controllers to
+        follow the waypoints trajectory.
+
+        :param debug: boolean flag to activate waypoints debugging
+        :return: control to be applied
+        """
+        if self._follow_speed_limits:
+            self._target_speed = self._vehicle.get_speed_limit()
+
+        # Add more waypoints too few in the horizon
+        if not self._stop_waypoint_creation and len(self._waypoints_queue) < self._min_waypoint_queue_length:
+            self._compute_next_waypoints(k=self._min_waypoint_queue_length)
+
+        # Purge the queue of obsolete waypoints
+        veh_location = self._vehicle.get_location()
+        vehicle_speed = get_speed(self._vehicle) / 3.6
+        self._min_distance = self._base_min_distance + self._distance_ratio * vehicle_speed
+
+        num_waypoint_removed = 0
+        for waypoint, _ in self._waypoints_queue:
+
+            if len(self._waypoints_queue) - num_waypoint_removed == 1:
+                min_distance = 1  # Don't remove the last waypoint until very close by
+            else:
+                min_distance = self._min_distance
+
+            if veh_location.distance(waypoint.transform.location) < min_distance:
+                num_waypoint_removed += 1
+            else:
+                break
+
+        if num_waypoint_removed > 0:
+            for _ in range(num_waypoint_removed):
+                self._waypoints_queue.popleft()
+
+        # Get the target waypoint and move using the PID controllers. Stop if no target waypoint
+        if len(self._waypoints_queue) == 0:
+            control = carla.VehicleControl()
+            control.steer = 0.0
+            control.throttle = 0.0
+            control.brake = 1.0
+            control.hand_brake = False
+            control.manual_gear_shift = False
+        else:
+            self.target_waypoint, self.target_road_option = self._waypoints_queue[0]
+            control = self._vehicle_controller.run_step(self._target_speed, self.target_waypoint)
+
+        if debug:
+            draw_waypoints(self._vehicle.get_world(), [self.target_waypoint], 1.0)
+
+        return control
+
+    def get_incoming_waypoint_and_direction(self, steps=3):
+        """
+        Returns direction and waypoint at a distance ahead defined by the user.
+
+            :param steps: number of steps to get the incoming waypoint.
+        """
+        if len(self._waypoints_queue) > steps:
+            return self._waypoints_queue[steps]
+
+        else:
+            try:
+                wpt, direction = self._waypoints_queue[-1]
+                return wpt, direction
+            except IndexError as i:
+                return None, RoadOption.VOID
+
+    def get_plan(self):
+        """Returns the current plan of the local planner"""
+        return self._waypoints_queue
+
+    def done(self):
+        """
+        Returns whether or not the planner has finished
+
+        :return: boolean
+        """
+        return len(self._waypoints_queue) == 0
+
+
+def _retrieve_options(list_waypoints, current_waypoint):
+    """
+    Compute the type of connection between the current active waypoint and the multiple waypoints present in
+    list_waypoints. The result is encoded as a list of RoadOption enums.
+
+    :param list_waypoints: list with the possible target waypoints in case of multiple options
+    :param current_waypoint: current active waypoint
+    :return: list of RoadOption enums representing the type of connection from the active waypoint to each
+             candidate in list_waypoints
+    """
+    options = []
+    for next_waypoint in list_waypoints:
+        # this is needed because something we are linking to
+        # the beggining of an intersection, therefore the
+        # variation in angle is small
+        next_next_waypoint = next_waypoint.next(3.0)[0]
+        link = _compute_connection(current_waypoint, next_next_waypoint)
+        options.append(link)
+
+    return options
+
+
+def _compute_connection(current_waypoint, next_waypoint, threshold=35):
+    """
+    Compute the type of topological connection between an active waypoint (current_waypoint) and a target waypoint
+    (next_waypoint).
+
+    :param current_waypoint: active waypoint
+    :param next_waypoint: target waypoint
+    :return: the type of topological connection encoded as a RoadOption enum:
+             RoadOption.STRAIGHT
+             RoadOption.LEFT
+             RoadOption.RIGHT
+    """
+    n = next_waypoint.transform.rotation.yaw
+    n = n % 360.0
+
+    c = current_waypoint.transform.rotation.yaw
+    c = c % 360.0
+
+    diff_angle = (n - c) % 180.0
+    if diff_angle < threshold or diff_angle > (180 - threshold):
+        return RoadOption.STRAIGHT
+    elif diff_angle > 90.0:
+        return RoadOption.LEFT
+    else:
+        return RoadOption.RIGHT

--- a/skycop/vendor/carla_agents/road_option.py
+++ b/skycop/vendor/carla_agents/road_option.py
@@ -1,0 +1,21 @@
+"""RoadOption enum extracted from CARLA's agents.navigation.local_planner.
+
+Vendored to avoid pulling the whole LocalPlanner chain (controller.py,
+tools/misc.py) when we only need the enum to talk to GlobalRoutePlanner.
+
+Upstream: https://github.com/carla-simulator/carla/blob/master/PythonAPI/carla/agents/navigation/local_planner.py
+License: MIT.
+"""
+
+from enum import IntEnum
+
+
+class RoadOption(IntEnum):
+    """Topological transitions between lane segments — see upstream."""
+    VOID = -1
+    LEFT = 1
+    RIGHT = 2
+    STRAIGHT = 3
+    LANEFOLLOW = 4
+    CHANGELANELEFT = 5
+    CHANGELANERIGHT = 6

--- a/tests/test_suspect_fsm.py
+++ b/tests/test_suspect_fsm.py
@@ -1,0 +1,287 @@
+"""Unit tests for skycop.sim.suspect_fsm — pure state machine, no CARLA."""
+
+from __future__ import annotations
+
+import pytest
+
+from skycop.sim.suspect_fsm import (
+    FSMConfig,
+    ParkingSubstate,
+    SuspectFSM,
+    SuspectState,
+    TMKnobs,
+)
+
+# ── Fixtures ──────────────────────────────────────────────────────────
+
+_FLEEING_KNOBS = TMKnobs(
+    speed_over_pct=-80.0, ignore_lights_pct=100.0, ignore_signs_pct=100.0,
+    lane_change_pct=50.0, follow_dist_m=1.0,
+)
+_ROAMING_KNOBS = TMKnobs(
+    speed_over_pct=0.0, ignore_lights_pct=0.0, ignore_signs_pct=0.0,
+    lane_change_pct=0.0, follow_dist_m=3.0,
+)
+def _cfg(**overrides) -> FSMConfig:
+    base = dict(
+        fleeing_duration_s=10.0,
+        roaming_duration_s=5.0,
+        parking_lot_timeout_s=20.0,
+        parking_roadside_timeout_s=10.0,
+        parked_confirm_timeout_s=60.0,
+        reach_distance_m=3.0,
+        reach_speed_mps=0.5,
+        ai_consecutive_lock_ticks=3,
+        fleeing_knobs=_FLEEING_KNOBS,
+        roaming_knobs=_ROAMING_KNOBS,
+        parking_lots=((100.0, 0.0, 0.0),),
+        roadside_spots=((200.0, 0.0, 0.0),),
+    )
+    base.update(overrides)
+    return FSMConfig(**base)
+
+
+def _tick(fsm, t, xy=(0.0, 0.0), speed=10.0, lock=False):
+    return fsm.tick(t, xy, speed, lock)
+
+
+# ── Initial tick ──────────────────────────────────────────────────────
+
+def test_first_tick_enters_fleeing_with_knobs():
+    fsm = SuspectFSM(cfg=_cfg())
+    r = _tick(fsm, 0.0)
+    assert r.state == SuspectState.FLEEING
+    assert r.action.apply_tm_knobs == _FLEEING_KNOBS
+    assert r.action.set_path_to is None
+    assert r.action.freeze_physics is False
+    assert r.terminal is False
+
+
+def test_fleeing_idle_ticks_emit_no_action():
+    fsm = SuspectFSM(cfg=_cfg())
+    _tick(fsm, 0.0)   # entry
+    r = _tick(fsm, 1.0)
+    assert r.state == SuspectState.FLEEING
+    assert r.action.apply_tm_knobs is None
+    assert r.action.set_path_to is None
+
+
+# ── FLEEING → ROAMING ─────────────────────────────────────────────────
+
+def test_fleeing_transitions_to_roaming_after_duration():
+    fsm = SuspectFSM(cfg=_cfg(fleeing_duration_s=10.0))
+    _tick(fsm, 0.0)
+    _tick(fsm, 9.9)                       # still FLEEING (< 10s)
+    r = _tick(fsm, 10.0)                  # boundary — transitions
+    assert r.state == SuspectState.ROAMING
+    assert r.action.apply_tm_knobs == _ROAMING_KNOBS
+
+
+# ── ROAMING → PARKING.TRYING_LOT ──────────────────────────────────────
+
+def test_roaming_transitions_to_parking_trying_lot():
+    fsm = SuspectFSM(cfg=_cfg(fleeing_duration_s=1.0, roaming_duration_s=1.0))
+    _tick(fsm, 0.0)
+    _tick(fsm, 1.0)                       # → ROAMING
+    r = _tick(fsm, 2.0)                   # → PARKING trying_lot
+    assert r.state == SuspectState.PARKING
+    assert r.parking_substate == ParkingSubstate.TRYING_LOT
+    assert r.action.apply_tm_knobs is None         # PARKING runs off-autopilot
+    assert r.action.set_path_to == (100.0, 0.0, 0.0)   # only candidate
+
+
+def test_parking_picks_nearest_lot():
+    fsm = SuspectFSM(cfg=_cfg(
+        fleeing_duration_s=1.0, roaming_duration_s=1.0,
+        parking_lots=((100.0, 0.0, 0.0), (50.0, 0.0, 0.0), (200.0, 0.0, 0.0)),
+    ))
+    _tick(fsm, 0.0)
+    _tick(fsm, 1.0)
+    r = _tick(fsm, 2.0, xy=(48.0, 0.0))   # closest to 50
+    assert r.action.set_path_to == (50.0, 0.0, 0.0)
+
+
+# ── PARKING → PARKED (happy path) ─────────────────────────────────────
+
+def test_reaching_parking_lot_enters_parked():
+    fsm = SuspectFSM(cfg=_cfg(fleeing_duration_s=1.0, roaming_duration_s=1.0))
+    _tick(fsm, 0.0)
+    _tick(fsm, 1.0)                                            # → ROAMING
+    _tick(fsm, 2.0, xy=(0.0, 0.0))                             # → PARKING
+    r = _tick(fsm, 3.0, xy=(100.5, 0.0), speed=0.1)            # arrived
+    assert r.state == SuspectState.PARKED
+    assert r.action.freeze_physics is True
+    assert r.countdown_s == 60.0
+
+
+def test_parking_not_reached_if_still_moving_fast():
+    fsm = SuspectFSM(cfg=_cfg(fleeing_duration_s=1.0, roaming_duration_s=1.0))
+    _tick(fsm, 0.0)
+    _tick(fsm, 1.0)
+    _tick(fsm, 2.0)
+    r = _tick(fsm, 3.0, xy=(100.0, 0.0), speed=5.0)  # close but not stopped
+    assert r.state == SuspectState.PARKING
+    assert r.parking_substate == ParkingSubstate.TRYING_LOT
+
+
+def test_parking_not_reached_if_too_far():
+    fsm = SuspectFSM(cfg=_cfg(fleeing_duration_s=1.0, roaming_duration_s=1.0))
+    _tick(fsm, 0.0)
+    _tick(fsm, 1.0)
+    _tick(fsm, 2.0)
+    r = _tick(fsm, 3.0, xy=(90.0, 0.0), speed=0.1)   # stopped but 10m away
+    assert r.state == SuspectState.PARKING
+
+
+# ── PARKING timeouts ──────────────────────────────────────────────────
+
+def test_lot_timeout_escalates_to_roadside():
+    fsm = SuspectFSM(cfg=_cfg(
+        fleeing_duration_s=1.0, roaming_duration_s=1.0,
+        parking_lot_timeout_s=5.0,
+    ))
+    _tick(fsm, 0.0)
+    _tick(fsm, 1.0)
+    _tick(fsm, 2.0, xy=(0.0, 0.0))                      # enter trying_lot
+    r = _tick(fsm, 7.0, xy=(10.0, 10.0), speed=10.0)    # 5s elapsed
+    assert r.state == SuspectState.PARKING
+    assert r.parking_substate == ParkingSubstate.TRYING_ROADSIDE
+    assert r.action.set_path_to == (200.0, 0.0, 0.0)
+
+
+def test_roadside_timeout_falls_through_to_park_in_place():
+    fsm = SuspectFSM(cfg=_cfg(
+        fleeing_duration_s=1.0, roaming_duration_s=1.0,
+        parking_lot_timeout_s=2.0, parking_roadside_timeout_s=2.0,
+    ))
+    _tick(fsm, 0.0)
+    _tick(fsm, 1.0)
+    _tick(fsm, 2.0)                                     # trying_lot
+    _tick(fsm, 4.0, xy=(10.0, 10.0), speed=10.0)        # → trying_roadside
+    r = _tick(fsm, 6.0, xy=(10.0, 10.0), speed=10.0)    # → park_in_place
+    assert r.state == SuspectState.PARKING
+    assert r.parking_substate == ParkingSubstate.PARK_IN_PLACE
+    # park-in-place has no knobs / no path — mission loop just brakes while
+    # the suspect is already off-autopilot from PARKING entry.
+    assert r.action.apply_tm_knobs is None
+    assert r.action.set_path_to is None
+
+
+def test_lot_timeout_skips_roadside_when_empty():
+    fsm = SuspectFSM(cfg=_cfg(
+        fleeing_duration_s=1.0, roaming_duration_s=1.0,
+        parking_lot_timeout_s=2.0, roadside_spots=(),
+    ))
+    _tick(fsm, 0.0)
+    _tick(fsm, 1.0)
+    _tick(fsm, 2.0)
+    r = _tick(fsm, 4.0, xy=(10.0, 10.0), speed=10.0)
+    assert r.state == SuspectState.PARKING
+    assert r.parking_substate == ParkingSubstate.PARK_IN_PLACE
+
+
+def test_park_in_place_transitions_to_parked_when_speed_drops():
+    fsm = SuspectFSM(cfg=_cfg(
+        fleeing_duration_s=1.0, roaming_duration_s=1.0,
+        parking_lot_timeout_s=1.0, roadside_spots=(),
+    ))
+    _tick(fsm, 0.0)
+    _tick(fsm, 1.0)
+    _tick(fsm, 2.0)
+    _tick(fsm, 3.0, xy=(10.0, 10.0), speed=10.0)     # → park_in_place
+    r = _tick(fsm, 4.0, xy=(10.0, 10.0), speed=0.1)  # stopped
+    assert r.state == SuspectState.PARKED
+    assert r.action.freeze_physics is True
+
+
+# ── PARKED submission logic ───────────────────────────────────────────
+
+def _drive_to_parked(fsm, t0=0.0):
+    """Fast-forward the FSM to PARKED, returning the t the mission is at."""
+    _tick(fsm, t0)
+    _tick(fsm, t0 + 1.0)                                # → ROAMING
+    _tick(fsm, t0 + 2.0)                                # → PARKING trying_lot
+    r = _tick(fsm, t0 + 3.0, xy=(100.0, 0.0), speed=0.1)
+    assert r.state == SuspectState.PARKED
+    return t0 + 3.0
+
+
+def test_parked_countdown_decrements_per_tick():
+    fsm = SuspectFSM(cfg=_cfg(
+        fleeing_duration_s=1.0, roaming_duration_s=1.0,
+        parked_confirm_timeout_s=60.0,
+    ))
+    t_park = _drive_to_parked(fsm)
+    r = _tick(fsm, t_park + 10.0, xy=(100.0, 0.0), speed=0.0)
+    assert r.countdown_s == pytest.approx(50.0)
+    assert r.submission is None
+    assert r.terminal is False
+
+
+def test_parked_ai_pass_after_k_consecutive_locks():
+    fsm = SuspectFSM(cfg=_cfg(
+        fleeing_duration_s=1.0, roaming_duration_s=1.0,
+        ai_consecutive_lock_ticks=3,
+    ))
+    t_park = _drive_to_parked(fsm)
+    r1 = _tick(fsm, t_park + 0.05, lock=True)
+    r2 = _tick(fsm, t_park + 0.10, lock=True)
+    r3 = _tick(fsm, t_park + 0.15, lock=True)
+    assert r1.submission is None
+    assert r2.submission is None
+    assert r3.submission == "ai_pass"
+    assert r3.terminal is True
+
+
+def test_parked_lock_streak_resets_on_break():
+    fsm = SuspectFSM(cfg=_cfg(
+        fleeing_duration_s=1.0, roaming_duration_s=1.0,
+        ai_consecutive_lock_ticks=3,
+    ))
+    t_park = _drive_to_parked(fsm)
+    _tick(fsm, t_park + 0.05, lock=True)
+    _tick(fsm, t_park + 0.10, lock=True)
+    _tick(fsm, t_park + 0.15, lock=False)    # streak broken
+    r = _tick(fsm, t_park + 0.20, lock=True)
+    # Would have fired on tick #3 without the break; now streak is back to 1.
+    assert r.submission is None
+
+
+def test_parked_timeout_emits_lose():
+    fsm = SuspectFSM(cfg=_cfg(
+        fleeing_duration_s=1.0, roaming_duration_s=1.0,
+        parked_confirm_timeout_s=5.0,
+    ))
+    t_park = _drive_to_parked(fsm)
+    # Tick inside the window — still running.
+    r_mid = _tick(fsm, t_park + 4.0, lock=False)
+    assert r_mid.submission is None
+    # Tick at/past the window — lose.
+    r_out = _tick(fsm, t_park + 5.0, lock=False)
+    assert r_out.submission == "timeout_lose"
+    assert r_out.terminal is True
+    assert r_out.countdown_s == 0.0
+
+
+def test_parked_ai_pass_wins_over_countdown_in_same_tick():
+    """If the lock-streak completes on the same tick the countdown hits 0, ai_pass wins."""
+    fsm = SuspectFSM(cfg=_cfg(
+        fleeing_duration_s=1.0, roaming_duration_s=1.0,
+        parked_confirm_timeout_s=0.2, ai_consecutive_lock_ticks=3,
+    ))
+    t_park = _drive_to_parked(fsm)
+    _tick(fsm, t_park + 0.05, lock=True)
+    _tick(fsm, t_park + 0.10, lock=True)
+    r = _tick(fsm, t_park + 0.20, lock=True)    # K=3 satisfied; window also expired
+    assert r.submission == "ai_pass"
+    assert r.terminal is True
+
+
+# ── Properties ────────────────────────────────────────────────────────
+
+def test_state_property_tracks_current_state():
+    fsm = SuspectFSM(cfg=_cfg(fleeing_duration_s=1.0))
+    _tick(fsm, 0.0)
+    assert fsm.state == SuspectState.FLEEING
+    _tick(fsm, 1.0)
+    assert fsm.state == SuspectState.ROAMING

--- a/tests/test_vendor_carla_agents.py
+++ b/tests/test_vendor_carla_agents.py
@@ -1,0 +1,39 @@
+"""Smoke tests for the vendored CARLA agents subset.
+
+No CARLA server required — we only verify the imports wire up correctly
+and the small hand-vendored helpers (RoadOption enum, vector helper)
+match upstream values.
+"""
+
+from __future__ import annotations
+
+from skycop.vendor.carla_agents import GlobalRoutePlanner, RoadOption
+from skycop.vendor.carla_agents._misc import vector
+
+
+def test_road_option_values_match_upstream():
+    # Pinned to the upstream enum (local_planner.RoadOption) — a silent
+    # drift here would change GlobalRoutePlanner's output.
+    assert RoadOption.VOID == -1
+    assert RoadOption.LEFT == 1
+    assert RoadOption.RIGHT == 2
+    assert RoadOption.STRAIGHT == 3
+    assert RoadOption.LANEFOLLOW == 4
+    assert RoadOption.CHANGELANELEFT == 5
+    assert RoadOption.CHANGELANERIGHT == 6
+
+
+def test_vector_is_unit_and_correct_direction():
+    class _L:
+        def __init__(self, x: float, y: float, z: float) -> None:
+            self.x, self.y, self.z = x, y, z
+    v = vector(_L(0.0, 0.0, 0.0), _L(3.0, 4.0, 0.0))
+    assert abs(v[0] - 0.6) < 1e-9
+    assert abs(v[1] - 0.8) < 1e-9
+    assert abs(v[2]) < 1e-9
+
+
+def test_global_route_planner_is_importable():
+    # Construction requires a carla.Map — skip that, just verify the class
+    # object is accessible through the public import path.
+    assert GlobalRoutePlanner.__name__ == "GlobalRoutePlanner"


### PR DESCRIPTION
## Summary

- Suspect FSM v0a — pure 4-state machine (FLEEING → ROAMING → PARKING → PARKED) with mixed time / destination transitions, 60 s PARKED confirmation window, bbox-centre-in-GT pass/fail grader. 18 unit tests, no CARLA.
- Vendored CARLA `GlobalRoutePlanner + LocalPlanner + VehiclePIDController` — `TrafficManager.set_path()` is empirically broken in 0.9.13–0.9.16 (reproducible via `scripts/11_parking_scout.py`); bypassing the TM with `set_autopilot(False)` + LocalPlanner is the working path.
- Mission loop integration — FSM action side-effects at CARLA boundary, per-state metrics breakdown in `summary.json`, ground-truth drone + suspect XY in `trace.jsonl`, MJPEG start trigger (operator can open page before any ticks fire), fingerprint thresholds tightened (0.30 → 0.50 rebind, 0.05 → 0.15 stickiness), altitude bumped 15 → 25 m to clear Town10HD overpasses.
- Follow-up: adaptive altitude + dispatch scan-high in #45 (supersedes D-12).

## Final demo run

| Metric | Value |
|---|---|
| FSM submission | **`ai_pass`** |
| Duration | 40.0 s (first-choice parking lot, no escalation) |
| id_accuracy | 0.987 |
| in_frame_rate | 1.000 |
| track_distance p95 | 1.63 m |

Per-state: FLEEING/ROAMING both perfect (id_acc 1.0, in_frame 1.0, sub-metre distance). PARKING id_acc 0.90 / p95 3.96 m. PARKED 4 ticks to confirmation.

## Test plan

- [x] `make test` — 128 unit tests, all pure (no CARLA): 20 new for FSM + vendored agents, existing 108 unchanged.
- [x] `make lint` — clean (`skycop/vendor/` excluded from ruff since it's upstream CARLA code).
- [x] Manual CARLA integration — one full mission run from Start click through AI-pass submission.
- [x] Feasibility test repro — `docker compose exec client python3 scripts/11_parking_scout.py --custom-controller --source 0 --target 10` reaches the target in ~18 s sim-time via vendored LocalPlanner. Without `--custom-controller` (naive `tm.set_path`), the vehicle never reaches it in 90 s.

## Not in this PR (by design)

- v0b (menu / mode selector) and v0c (user-controlled drone + draw-bbox submission UI) — separate slices.
- Adaptive altitude + dispatch scan-high — #45.
- Parking-lot geometry inference (FR-11 full version) — hand-picked Town10HD spawn points for v0a.
- CV-26 nadir pitch snap, CV-27..32 parked-suspect re-ID, dispatch bootstrap (FR-03).

## Decision record

D-14 added to `docs/design.md` — mixed transitions, pass/fail grading, custom PARKING controller with vendored CARLA agents, per-state metric breakdown. D-12 kept but noted in #45 as being superseded once that issue lands. FR-07..11 moved ⬜ → 🔨 in `REQUIREMENTS.md`.