### PR TITLE
Mission v0c: user-controlled drone + draw-bbox submission + replay loop (closes #49)

### DIFF
--- a/configs/mission.yaml
+++ b/configs/mission.yaml
@@ -3,7 +3,7 @@
 
 mission:
   duration_s: 240.0            # safety cap (v0a FSM usually terminates earlier on AI submission or 60s PARKED timeout)
-  altitude_m: 25.0             # v0a bump 15→25 — clears the Town10HD monorail/walkway overpasses (Buildings@12.3m, RailTrack@7.2m). D-12 superseded; see issue #45 for adaptive altitude follow-up.
+  altitude_m: 40.0             # v0c bump 25→40 — wider FOV for the eventual dispatch search phase and more clearance above Town10HD overhead structures (tallest over-road deck is 12.3 m). Adaptive per-phase altitude (scan-high at dispatch, pursuit-low, climb-over on obstacle approach) is issue #45. D-12 superseded.
   weather: ClearNoon           # SIM-06 — one of ClearNoon / CloudyNight / WetCloudyNoon
   output_root: /app/output/mission
   video_fps: 20                # matches carla.fixed_delta_seconds = 0.05

--- a/docs/design.md
+++ b/docs/design.md
@@ -477,6 +477,45 @@ Plus a per-tick `trace.jsonl` (`drone_to_suspect_m`, `center_offset_px`, `veloci
 
 ---
 
+### D-16 · v0c user-controlled drone mode — WASD-QE flight, slide-along collision, draw-bbox submission
+
+**Status:** Decided · **Date:** 2026-04-22 · **Issue:** #49
+
+**Context.** v0a shipped the autonomous pipeline; v0b added a menu with a "Manual Pursuit" placeholder button. v0c makes that button live — the user flies the drone themselves and submits a bounding box on the parked suspect, graded by the same rule as AI mode. The pursuit pipeline (YOLO + ByteTrack + HSV fingerprint + flight PID) is disabled in user mode; the suspect FSM still runs.
+
+**Decisions.**
+
+1. **Drone-heading-follow control scheme (Option B).** Camera yaw = drone body yaw; W / S = body-forward / back; A / D = body-strafe; Q / E = yaw at 60°/s (config-tunable); Shift / Ctrl = altitude ± 5 m/s. **Snappy feel** (no momentum, per v0c grill) — key pressed → full velocity; released → zero. The contrasting option (A, fixed north-up) was considered and rejected because the user explicitly valued real-drone-like immersion; B matches consumer/FPV drone conventions ([DJI Mode 2](https://steamcommunity.com/app/2707940/discussions/0/4526764457370298140/)). The common disorientation argument against B is mitigated by our auto-gimballed camera (pitch fixed at −75°, no cockpit tilt) + visible colour-coded state panel.
+
+2. **WebSocket input transport (`flask-sock`).** JS sends `keydown`/`keyup` events as they happen; server maintains a thread-safe pressed-key set; mission loop snapshots it each tick. HTTP polling was considered — would have been adequate for 20 Hz tick rate — but the event-based WebSocket model avoids the "did my keyup get lost?" class of bugs and costs one trivial pip dep.
+
+3. **Slide-along collision (walls + ground).** `skycop.control.collision.apply_slide_along` casts a ray from the drone's current position to the intended pose; on hit, motion is decomposed into (parallel-to-surface, kept) + (perpendicular-to-surface, blocked) using the hit normal estimated from the hit-point-to-drone vector. Ground floor handled by `UserDroneConfig.min_altitude_m`. CARLA's `world.cast_ray` in 0.9.16 returns labels but no explicit normals — the from-hit-to-drone estimate works well enough for AABB-approximated urban geometry. Soft-gate fallback is implicit (degenerate normal → cancel the motion entirely).
+
+4. **Draw-bbox + Submit both gate on `FSM.state == PARKED`.** (v0c grill 5a-i + 5b-ii.) During FLEEING / ROAMING / PARKING, the user just flies to keep the suspect on screen; no bbox drawing, no submit. On PARKED entry, the canvas unlocks (pointer-events: auto) and the Submit button turns primary green. The user has the same 60 s countdown as AI mode. This makes the game fair across modes (both get one 60 s submission window) and prevents pre-committing to a rolling target.
+
+5. **Colour-coded state panel replaces the v0a HUD flash.** Persistent top-left panel: FLEEING red / ROAMING orange / PARKING yellow / PARKED green. Panel updates via `GET /state` polled every 250 ms by the page. PARKED shows the live countdown. Rationale: one-time flashes are easy to miss during active pursuit; a persistent colour cue is scannable at a glance without drawing attention away from the camera.
+
+6. **Grading is identical to AI mode — bbox-centre-in-GT projection, pass / fail.** Outcomes written to `summary.json.fsm_submission`: `user_pass`, `user_fail`, `timeout_lose`. Failing to reach a parking lot is still not a lose condition; only failing to submit within 60 s post-PARKED is. Same semantics as D-14.
+
+7. **AI pipeline strictly disabled in user mode.** Mission loop constructs `ByteTrackAdapter` / `PursuitPID` / `TargetStateTracker` only when `mode == 'ai'`. YOLO weights are only required in AI mode. The overlay in user mode also omits GT bboxes and tracker boxes — the user finds the suspect themselves, no cheats. Keeping both modes in one `mission.run_mission` function rather than two parallel entrypoints means the FSM, scene setup, summary output, and trace writing all stay shared and consistent.
+
+8. **Menu wires `mode=ai|user` through `POST /start`.** The v0b menu's two cards each POST a hidden `mode` field. Server stores the selected mode, and `run_mission` reads it after `wait_for_start()`. `cfg.mission.mode` is honoured as the default if no menu is attached (e.g., headless tests).
+
+**Deferred to v0d and beyond:**
+
+- Momentum / inertia flight model — snappy may feel arcadey; upgrade if playtesting says so.
+- Gamepad input — keyboard-only for v0c.
+- Nadir-pitch snap during draw-bbox (press Tab to switch from −75° to −90° for flatter bbox geometry).
+- Replay / record mode for human-vs-AI A/B comparisons (§6.4 requirement).
+
+**Open risks (v0c playtest watch list):**
+
+- Hit-normal estimation quality in complex geometry — fallback is soft-gate.
+- Yaw rate (60°/s) may be too slow; it's config-tunable.
+- Bbox precision at altitude 25 m / pitch −75° — small cars are ~30–50 px wide. May need the nadir snap if playtesting is frustrating.
+
+---
+
 ## 13. Open Questions
 
 - **Suspect FSM owner.** ~~Scripts 03/04 use TM autopilot with reckless knobs. The proper Fleeing→Roaming→Parking→Parked FSM (FR-07..11) is deferred.~~ Resolved by D-14 — FSM lives in `skycop.sim.suspect_fsm`, CARLA side-effects in the mission loop.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "numpy",
     "opencv-python-headless",
     "flask",
+    "flask-sock",                  # v0c: WebSocket input for manual drone mode
     "omegaconf",
     "ultralytics",                 # YOLOv8 — pulls torch+torchvision (~800 MB on first build)
     "torchmetrics[detection]",     # mAP computation (the [detection] extra pulls pycocotools)

--- a/skycop/control/__init__.py
+++ b/skycop/control/__init__.py
@@ -1,9 +1,17 @@
-"""Drone control — PID + target-state estimation."""
+"""Drone control — PID + target-state estimation + manual user control."""
 
 from skycop.control.pursuit_pid import PursuitPID
 from skycop.control.target_state import TargetStateTracker
+from skycop.control.user_drone import (
+    Pose,
+    UserDroneConfig,
+    UserDroneController,
+)
 
 __all__ = [
+    "Pose",
     "PursuitPID",
     "TargetStateTracker",
+    "UserDroneConfig",
+    "UserDroneController",
 ]

--- a/skycop/control/collision.py
+++ b/skycop/control/collision.py
@@ -1,0 +1,103 @@
+"""Slide-along collision for the user-mode drone (v0c).
+
+CARLA integration lives here, not in user_drone.py, so the pure pose
+controller stays test-only-pure. Each tick:
+
+1. UserDroneController computes an *intended* pose from key input.
+2. This module casts a ray from the current drone position toward the
+   intended position; if the ray hits a non-Road / non-Vehicle surface,
+   it decomposes the motion into (parallel-to-surface, kept) +
+   (perpendicular-to-surface, blocked) using the hit normal.
+3. Returns the safe pose to commit.
+
+If the ray hit's label is outside a small *pass-through* allow-list
+(Road / RoadLines / Vehicles / Sky / NONE), we treat it as solid.
+
+Ground floor handled by ``user_drone.UserDroneController`` via
+``min_altitude_m`` — this module only deals with vertical structures.
+"""
+
+from __future__ import annotations
+
+import carla
+
+from skycop.control.user_drone import Pose
+
+# Ray labels we treat as passable (drone is non-collision aerial camera,
+# but we mark these as "ok to fly through" explicitly).
+_PASSABLE_LABELS: frozenset[str] = frozenset(
+    {"Roads", "RoadLines", "Vehicles", "NONE", "Sky", "Terrain"}
+)
+
+
+def apply_slide_along(
+    world: carla.World,
+    current: Pose,
+    intended: Pose,
+    drone_radius_m: float = 0.75,
+) -> Pose:
+    """Project ``intended`` onto the allowed slide plane if it would collide.
+
+    If the cast from ``current`` to ``intended`` is clear, returns
+    ``intended`` unchanged. Otherwise decomposes the motion using the
+    hit normal; if the normal cannot be recovered (CARLA returns only
+    a label + point on ``cast_ray`` in 0.9.16), falls back to *soft gate*
+    — cancel horizontal motion this tick, keep vertical.
+    """
+    # Altitude-only move: skip the cast (ground floor handled upstream).
+    dx = intended.x - current.x
+    dy = intended.y - current.y
+    if dx == 0.0 and dy == 0.0:
+        return intended
+
+    # Extend the ray by the drone radius so we stop *before* touching.
+    mag = (dx * dx + dy * dy) ** 0.5
+    ext = (drone_radius_m / mag) if mag > 0 else 0.0
+    start = carla.Location(current.x, current.y, current.z)
+    end = carla.Location(
+        intended.x + dx * ext,
+        intended.y + dy * ext,
+        intended.z,
+    )
+    hits = world.cast_ray(start, end)
+    blocker = _first_blocker(hits)
+    if blocker is None:
+        return intended
+
+    # CARLA's LabelledPoint (0.9.16) gives us label + location. No normal.
+    # Estimate one from hit geometry: the normal lies in the horizontal plane
+    # pointing from the hit back toward the current position (AABB approx).
+    hx = blocker.location.x
+    hy = blocker.location.y
+    nx = current.x - hx
+    ny = current.y - hy
+    nmag = (nx * nx + ny * ny) ** 0.5
+    if nmag < 1e-6:
+        # Degenerate — we're right on top of the hit. Soft-gate.
+        return Pose(x=current.x, y=current.y, z=intended.z, yaw_rad=intended.yaw_rad)
+    nx /= nmag
+    ny /= nmag
+
+    # Decompose the requested motion into (parallel, perpendicular) w.r.t. normal.
+    # perp = (v · n) n,  parallel = v - perp.  We keep only the parallel component.
+    v_dot_n = dx * nx + dy * ny
+    # If motion is away from the wall (v · n > 0), there's no conflict — let it through.
+    if v_dot_n > 0:
+        return intended
+    slide_x = dx - v_dot_n * nx
+    slide_y = dy - v_dot_n * ny
+    return Pose(
+        x=current.x + slide_x,
+        y=current.y + slide_y,
+        z=intended.z,
+        yaw_rad=intended.yaw_rad,
+    )
+
+
+def _first_blocker(hits):
+    """Return the first ray hit whose label isn't in the pass-through set."""
+    for h in hits:
+        label_name = str(h.label).split(".")[-1]
+        if label_name not in _PASSABLE_LABELS:
+            return h
+    return None

--- a/skycop/control/user_drone.py
+++ b/skycop/control/user_drone.py
@@ -1,0 +1,111 @@
+"""User drone controller — body-frame snappy WASD-QE flight.
+
+Pure-logic module; no CARLA. Given a pose (x, y, z, yaw) and a set of
+currently-pressed keys, computes the commanded pose for the next tick.
+
+Convention (per v0c grill — option B "drone-heading follow"):
+
+- ``yaw_rad`` — drone body heading in world frame. Camera yaw follows.
+- **W** → drone-forward  (world Δ = (cos yaw, sin yaw) · speed).
+- **S** → drone-back.
+- **A / D** → strafe left / right in body frame.
+- **Q / E** → yaw left / right at ``yaw_rate_deg_s``.
+- **Shift / Ctrl** → altitude up / down at ``altitude_rate_mps``.
+
+Snappy feel (no momentum): pressed key → max velocity that axis, released
+→ zero. Velocities clamp per-axis at ``max_speed_mps``. Collision handling
+is out of scope — the mission loop applies raycast slide-along after this
+returns.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+_TRACKED_KEYS = frozenset(["w", "a", "s", "d", "q", "e", "shift", "control"])
+
+
+@dataclass(frozen=True)
+class UserDroneConfig:
+    max_speed_mps: float = 20.0             # body-frame horizontal cap
+    altitude_rate_mps: float = 5.0          # vertical
+    yaw_rate_deg_s: float = 60.0            # deg per second while Q / E held
+    min_altitude_m: float = 1.0             # ground clearance floor
+
+
+@dataclass
+class Pose:
+    x: float
+    y: float
+    z: float
+    yaw_rad: float
+
+
+@dataclass
+class UserDroneController:
+    cfg: UserDroneConfig = field(default_factory=UserDroneConfig)
+
+    # ── Public API ──────────────────────────────────────────────────
+
+    def step(
+        self,
+        pose: Pose,
+        pressed: frozenset[str] | set[str],
+        dt: float,
+    ) -> Pose:
+        """Return the commanded pose after ``dt`` seconds of input."""
+        if dt <= 0:
+            raise ValueError(f"dt must be > 0, got {dt}")
+
+        pressed = {k.lower() for k in pressed} & set(_TRACKED_KEYS)
+
+        # ── Yaw rate ──
+        yaw_rate_rad = math.radians(self.cfg.yaw_rate_deg_s)
+        dyaw = 0.0
+        if "q" in pressed:
+            dyaw -= yaw_rate_rad * dt
+        if "e" in pressed:
+            dyaw += yaw_rate_rad * dt
+        new_yaw = self._wrap_rad(pose.yaw_rad + dyaw)
+
+        # ── Body-frame WASD → world velocity ──
+        # Body +X = forward, body +Y = right (CARLA left-handed convention).
+        fwd = 0.0
+        right = 0.0
+        if "w" in pressed:
+            fwd += 1.0
+        if "s" in pressed:
+            fwd -= 1.0
+        if "d" in pressed:
+            right += 1.0
+        if "a" in pressed:
+            right -= 1.0
+        mag = math.hypot(fwd, right)
+        if mag > 1.0:
+            fwd /= mag
+            right /= mag
+        # Use the *current* yaw (not the post-rotation one) for motion —
+        # keeps the drone moving in the direction it was actually facing
+        # at the start of the tick.
+        vx_world = (fwd * math.cos(pose.yaw_rad) - right * math.sin(pose.yaw_rad)) * self.cfg.max_speed_mps
+        vy_world = (fwd * math.sin(pose.yaw_rad) + right * math.cos(pose.yaw_rad)) * self.cfg.max_speed_mps
+        new_x = pose.x + vx_world * dt
+        new_y = pose.y + vy_world * dt
+
+        # ── Altitude ──
+        vz = 0.0
+        if "shift" in pressed:
+            vz += self.cfg.altitude_rate_mps
+        if "control" in pressed:
+            vz -= self.cfg.altitude_rate_mps
+        new_z = max(self.cfg.min_altitude_m, pose.z + vz * dt)
+
+        return Pose(x=new_x, y=new_y, z=new_z, yaw_rad=new_yaw)
+
+    # ── Helpers ─────────────────────────────────────────────────────
+
+    @staticmethod
+    def _wrap_rad(a: float) -> float:
+        """Wrap ``a`` to (-π, π]."""
+        return (a + math.pi) % (2 * math.pi) - math.pi

--- a/skycop/dashboard/mjpeg.py
+++ b/skycop/dashboard/mjpeg.py
@@ -104,7 +104,7 @@ _LIVE_USER_HTML = """<!DOCTYPE html>
 <div id="end">
   <h1 id="end-title">—</h1>
   <p id="end-detail">—</p>
-  <a href="/">Back to menu</a>
+  <a href="/menu">Back to menu</a>
 </div>
 
 <script>
@@ -342,6 +342,15 @@ class MJPEGServer:
             with self._lock:
                 self._started_mode = mode
             self._start_event.set()
+            return redirect(url_for("_index"))
+
+        @self.app.route("/menu")
+        def _menu() -> Response:
+            # "Back to menu" link in the end modal — force-rearm the server
+            # so the splash shows even if the previous round hasn't fully
+            # torn down yet, then redirect. Eliminates a race where the
+            # browser would land on the stale live page.
+            self.reset_for_menu()
             return redirect(url_for("_index"))
 
         @self.app.route("/stream")

--- a/skycop/dashboard/mjpeg.py
+++ b/skycop/dashboard/mjpeg.py
@@ -444,6 +444,22 @@ class MJPEGServer:
         with self._lock:
             self._submission = None
 
+    def reset_for_menu(self) -> None:
+        """Rearm the server for a fresh round: clear the start event, drop
+        held keys, clear any pending submission, and reset the FSM snapshot
+        so the page shows the splash menu again and ``wait_for_start()``
+        blocks until the user picks a mode a second time.
+        """
+        with self._lock:
+            self._start_event.clear()
+            self._pressed.clear()
+            self._submission = None
+            self._fsm_state = "fleeing"
+            self._fsm_countdown_s = None
+            self._fsm_terminal = False
+            self._fsm_result = None
+            self._started_mode = "ai"
+
     # ── MJPEG plumbing ──────────────────────────────────────────────
 
     def _generate(self):

--- a/skycop/dashboard/mjpeg.py
+++ b/skycop/dashboard/mjpeg.py
@@ -1,36 +1,36 @@
-"""Flask-based MJPEG streamer for live CARLA camera frames.
+"""Flask MJPEG streamer + menu + user-mode game server.
 
-Usage:
+Serves three surfaces in v0c:
 
-    server = MJPEGServer(title="Experiment 03 — suspect follow")
-    server.start(port=5000)
-    # ... in a CARLA loop:
-    server.push(frame_bgr)
+- ``/`` — splash menu with two modes (AI / Manual) until ``POST /start``
+  fires, then the per-mode live view. Selected mode is captured in the
+  form field ``mode`` (``ai`` or ``user``).
+- ``/stream`` — MJPEG multipart stream of the latest camera frame.
+- ``/ws/input`` — WebSocket for keydown/keyup events in manual mode.
+  The mission loop reads the current pressed-key set each tick.
+- ``POST /submit`` — user-mode bbox submission (JSON body
+  ``{"bbox": [x1, y1, x2, y2]}``). Mission loop polls ``get_submission()``.
+- ``GET /state`` — JSON snapshot of FSM state + countdown + terminal result,
+  used by the manual page to colour its state panel and drive the submit
+  button / end modal.
 
-Scripts that need extra routes (e.g. keyboard capture) can attach them to
-`server.app` before calling `start()`, or pass a custom `html` to override
-the index page.
-
-The server runs Flask on a daemon thread so the caller's main loop keeps
-ticking CARLA. Frames are held behind a lock and served on `/stream`.
-
-Optional start trigger (v0a, issue #44): construct with ``use_start_trigger=True``.
-The index page renders a *splash* with a "Start pursuit" button until the
-user clicks it (``POST /start``). ``wait_for_start(timeout)`` blocks until
-fired — the mission loop calls this before spawning NPCs so you can open
-the page before any world ticks happen.
+Threading: Flask runs on a daemon thread. Frames, pressed-key set, game
+state, and submission slot are all held behind the same ``_lock`` so the
+mission loop can snapshot them without racing WebSocket / HTTP handlers.
 """
 
 from __future__ import annotations
 
+import json
 import threading
 import time
 
 import cv2
 import numpy as np
-from flask import Flask, Response, redirect, url_for
+from flask import Flask, Response, redirect, request, url_for
+from flask_sock import Sock
 
-_LIVE_HTML = """<!DOCTYPE html>
+_LIVE_AI_HTML = """<!DOCTYPE html>
 <html><head><title>{title}</title>
 <style>
   body {{ margin: 0; background: #111; color: #eee; font-family: monospace; }}
@@ -41,6 +41,194 @@ _LIVE_HTML = """<!DOCTYPE html>
 </head><body>
 <img src="/stream"/>
 <div id="hud">{hud}</div>
+</body></html>"""
+
+_LIVE_USER_HTML = """<!DOCTYPE html>
+<html><head><title>{title} — Manual Pursuit</title>
+<style>
+  body {{ margin: 0; background: #111; color: #eee;
+          font-family: ui-monospace, Menlo, Consolas, monospace; overflow: hidden; }}
+  #stage {{ position: relative; width: 100vw; height: 100vh; }}
+  img  {{ width: 100%; height: 100%; object-fit: contain; display: block;
+          position: absolute; inset: 0; }}
+  canvas {{ position: absolute; inset: 0; width: 100%; height: 100%;
+            cursor: crosshair; pointer-events: none; }}
+  canvas.active {{ pointer-events: auto; }}
+  #panel {{ position: fixed; top: 12px; left: 12px;
+            background: rgba(0,0,0,0.82); padding: 10px 14px; border-radius: 8px;
+            font-size: 14px; display: flex; flex-direction: column; gap: 4px;
+            min-width: 220px; border: 2px solid #333; }}
+  #panel .state {{ font-size: 17px; font-weight: bold; letter-spacing: 0.07em; }}
+  #panel .hint  {{ font-size: 12px; color: #bbb; }}
+  #panel.fleeing {{ border-color: #e14; }} #panel.fleeing .state {{ color: #f66; }}
+  #panel.roaming {{ border-color: #f90; }} #panel.roaming .state {{ color: #fa4; }}
+  #panel.parking {{ border-color: #fc3; }} #panel.parking .state {{ color: #fd6; }}
+  #panel.parked  {{ border-color: #4e8; }} #panel.parked  .state {{ color: #6f8; }}
+  #controls {{ position: fixed; top: 12px; right: 12px;
+               background: rgba(0,0,0,0.75); padding: 10px 14px;
+               border-radius: 8px; font-size: 12px; color: #bbb; line-height: 1.7; }}
+  #submit {{ position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
+             padding: 12px 32px; font-size: 16px; font-family: inherit;
+             background: #333; color: #888; border: 0; border-radius: 6px;
+             cursor: not-allowed; letter-spacing: 0.05em; }}
+  #submit.ready {{ background: #7fd; color: #111; cursor: pointer; }}
+  #submit.ready:hover {{ background: #4be; }}
+  #end {{ position: fixed; inset: 0; background: rgba(0,0,0,0.85);
+          display: none; align-items: center; justify-content: center;
+          flex-direction: column; gap: 1.5rem; z-index: 50; }}
+  #end.show {{ display: flex; }}
+  #end h1 {{ margin: 0; font-size: 2.2rem; }}
+  #end h1.win {{ color: #7fd; }} #end h1.lose {{ color: #f66; }}
+  #end p  {{ margin: 0; color: #ccc; max-width: 30rem; text-align: center; }}
+  #end a  {{ background: #7fd; color: #111; padding: 0.75rem 1.75rem;
+             text-decoration: none; border-radius: 0.5rem; font-family: inherit;
+             font-weight: bold; letter-spacing: 0.05em; }}
+</style>
+</head><body>
+<div id="stage">
+  <img src="/stream"/>
+  <canvas id="canvas"></canvas>
+</div>
+<div id="panel" class="fleeing">
+  <div class="state">FLEEING</div>
+  <div class="hint">connecting…</div>
+</div>
+<div id="controls">
+  <b>W/S</b> forward · back<br>
+  <b>A/D</b> strafe left · right<br>
+  <b>Q/E</b> yaw left · right<br>
+  <b>Shift/Ctrl</b> ascend · descend<br>
+  <br><b>PARKED</b>: draw bbox · click Submit
+</div>
+<button id="submit" disabled>Submit (wait for PARKED)</button>
+<div id="end">
+  <h1 id="end-title">—</h1>
+  <p id="end-detail">—</p>
+  <a href="/">Back to menu</a>
+</div>
+
+<script>
+// ── WebSocket input ───────────────────────────────────────────────
+const ws = new WebSocket((location.protocol === 'https:' ? 'wss://' : 'ws://') + location.host + '/ws/input');
+const sendKey = (type, key) => {{
+  if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({{type, key}}));
+}};
+const trackedKeys = new Set(['w', 'a', 's', 'd', 'q', 'e', 'shift', 'control']);
+const normKey = (e) => {{
+  let k = e.key.toLowerCase();
+  if (k === 'w' || k === 'a' || k === 's' || k === 'd' || k === 'q' || k === 'e') return k;
+  if (k === 'shift') return 'shift';
+  if (k === 'control') return 'control';
+  return null;
+}};
+window.addEventListener('keydown', e => {{
+  const k = normKey(e); if (k && trackedKeys.has(k)) {{ sendKey('keydown', k); e.preventDefault(); }}
+}});
+window.addEventListener('keyup', e => {{
+  const k = normKey(e); if (k && trackedKeys.has(k)) {{ sendKey('keyup', k); e.preventDefault(); }}
+}});
+// Release all keys on blur so focus loss doesn't strand a held key
+window.addEventListener('blur', () => trackedKeys.forEach(k => sendKey('keyup', k)));
+
+// ── Bbox canvas ───────────────────────────────────────────────────
+const canvas = document.getElementById('canvas');
+const ctx = canvas.getContext('2d');
+let bbox = null, dragging = false, dragStart = null;
+const fitCanvas = () => {{
+  canvas.width = canvas.clientWidth; canvas.height = canvas.clientHeight;
+  redraw();
+}};
+window.addEventListener('resize', fitCanvas);
+const redraw = () => {{
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  if (bbox) {{
+    ctx.strokeStyle = '#4e8'; ctx.lineWidth = 3;
+    ctx.strokeRect(bbox[0], bbox[1], bbox[2]-bbox[0], bbox[3]-bbox[1]);
+    ctx.fillStyle = 'rgba(78, 232, 136, 0.12)';
+    ctx.fillRect(bbox[0], bbox[1], bbox[2]-bbox[0], bbox[3]-bbox[1]);
+  }}
+}};
+canvas.addEventListener('mousedown', e => {{
+  if (!canvas.classList.contains('active')) return;
+  const r = canvas.getBoundingClientRect();
+  dragStart = [e.clientX - r.left, e.clientY - r.top];
+  dragging = true; bbox = null;
+}});
+canvas.addEventListener('mousemove', e => {{
+  if (!dragging) return;
+  const r = canvas.getBoundingClientRect();
+  const now = [e.clientX - r.left, e.clientY - r.top];
+  bbox = [Math.min(dragStart[0], now[0]), Math.min(dragStart[1], now[1]),
+          Math.max(dragStart[0], now[0]), Math.max(dragStart[1], now[1])];
+  redraw();
+}});
+canvas.addEventListener('mouseup', () => {{ dragging = false; }});
+fitCanvas();
+
+// ── Submit ───────────────────────────────────────────────────────
+const submit = document.getElementById('submit');
+submit.addEventListener('click', async () => {{
+  if (!submit.classList.contains('ready') || !bbox) return;
+  // Convert canvas pixel coords → image pixel coords ({width}×{height}).
+  const sx = {width} / canvas.clientWidth;
+  const sy = {height} / canvas.clientHeight;
+  const imgBbox = [bbox[0] * sx, bbox[1] * sy, bbox[2] * sx, bbox[3] * sy];
+  submit.disabled = true;
+  await fetch('/submit', {{
+    method: 'POST', headers: {{'Content-Type': 'application/json'}},
+    body: JSON.stringify({{bbox: imgBbox}}),
+  }});
+}});
+
+// ── Game state polling ───────────────────────────────────────────
+const panel = document.getElementById('panel');
+const stateLabel = panel.querySelector('.state');
+const hintLabel = panel.querySelector('.hint');
+const endPanel = document.getElementById('end');
+const endTitle = document.getElementById('end-title');
+const endDetail = document.getElementById('end-detail');
+const hints = {{
+  fleeing: 'Suspect fleeing — keep visual',
+  roaming: 'Suspect roaming — maintain pursuit',
+  parking: 'Suspect parking — hold position',
+  parked:  'Draw bbox · submit',
+}};
+async function pollState() {{
+  try {{
+    const r = await fetch('/state'); const s = await r.json();
+    stateLabel.textContent = s.state.toUpperCase();
+    hintLabel.textContent = hints[s.state] || '';
+    if (s.state === 'parked' && s.countdown_s != null) {{
+      hintLabel.textContent = `Draw bbox · submit · ${{s.countdown_s.toFixed(1)}}s`;
+    }}
+    panel.className = s.state;
+    // Canvas + submit enable only when PARKED
+    if (s.state === 'parked' && !s.terminal) {{
+      canvas.classList.add('active');
+      submit.classList.add('ready'); submit.disabled = false;
+      submit.textContent = 'Submit bbox';
+    }} else {{
+      canvas.classList.remove('active');
+      submit.classList.remove('ready'); submit.disabled = true;
+      submit.textContent = s.terminal ? 'Round over' : 'Submit (wait for PARKED)';
+    }}
+    if (s.terminal) {{
+      endPanel.classList.add('show');
+      const win = s.result === 'user_pass';
+      endTitle.textContent = win ? 'Pursuit confirmed' : 'Suspect lost';
+      endTitle.className = win ? 'win' : 'lose';
+      const detail = {{
+        user_pass: 'Your bbox covered the parked suspect. Good pursuit.',
+        user_fail: 'Bbox was drawn but did not cover the suspect. Try again.',
+        timeout_lose: 'The 60-second confirmation window expired with no submission. The suspect is gone.',
+      }};
+      endDetail.textContent = detail[s.result] || 'Round ended.';
+    }}
+  }} catch (e) {{ /* server restarting or paused — keep polling */ }}
+}}
+setInterval(pollState, 250);
+pollState();
+</script>
 </body></html>"""
 
 _SPLASH_HTML = """<!DOCTYPE html>
@@ -75,20 +263,24 @@ _SPLASH_HTML = """<!DOCTYPE html>
   <div class="mode">
     <h2>AI Pursuit</h2>
     <p>The drone follows a reckless suspect autonomously using YOLO + ByteTrack + HSV re-ID. Watch the live camera feed while the flight PID keeps the suspect centred. Mission auto-ends on parked-car confirmation.</p>
-    <form method="POST" action="/start"><button type="submit">Start AI Pursuit</button></form>
+    <form method="POST" action="/start"><input type="hidden" name="mode" value="ai"/>
+      <button type="submit">Start AI Pursuit</button>
+    </form>
   </div>
-  <div class="mode disabled">
+  <div class="mode">
     <h2>Manual Pursuit</h2>
-    <p>Fly the drone yourself. Chase the suspect, draw a bounding box on the parked vehicle, submit. Coming in v0c — manual drone controls and the draw-bbox submission UI.</p>
-    <button type="button" disabled>Coming in v0c</button>
+    <p>Fly the drone yourself with WASD + QE + Shift/Ctrl. Chase the suspect, then when it parks draw a bounding box and submit within 60 seconds.</p>
+    <form method="POST" action="/start"><input type="hidden" name="mode" value="user"/>
+      <button type="submit">Start Manual Pursuit</button>
+    </form>
   </div>
 </div>
-<p class="version">v0b · Mission SkyCop</p>
+<p class="version">v0c · Mission SkyCop</p>
 </body></html>"""
 
 
 class MJPEGServer:
-    """Minimal MJPEG server. One stream, one frame buffer, optional start trigger."""
+    """MJPEG stream + menu + v0c user-mode game server."""
 
     def __init__(
         self,
@@ -96,31 +288,59 @@ class MJPEGServer:
         hud: str = "",
         html: str | None = None,
         use_start_trigger: bool = False,
+        image_size: tuple[int, int] = (720, 1280),  # (h, w) — matches camera
     ) -> None:
         self._title = title
         self._hud = hud or title
         self._html = html
+        self._image_size = image_size
         self._frame: np.ndarray | None = None
         self._lock = threading.Lock()
+
+        # Start-trigger gate (v0a).
         self._use_start_trigger = use_start_trigger
         self._start_event = threading.Event()
         if not use_start_trigger:
-            # Backwards-compatible: servers without a splash just start already-ready.
             self._start_event.set()
+        self._started_mode: str = "ai"  # set on /start
+
+        # Per-tick FSM snapshot the page polls via GET /state (v0c).
+        self._fsm_state: str = "fleeing"
+        self._fsm_countdown_s: float | None = None
+        self._fsm_terminal: bool = False
+        self._fsm_result: str | None = None
+
+        # User-mode input + submission slots (v0c).
+        self._pressed: set[str] = set()
+        self._submission: dict | None = None
+
         self.app = Flask(__name__)
+        self._sock = Sock(self.app)
         self._register_routes()
+
+    # ── Flask wiring ────────────────────────────────────────────────
 
     def _register_routes(self) -> None:
         @self.app.route("/")
         def _index() -> str:
             if self._use_start_trigger and not self._start_event.is_set():
-                return _SPLASH_HTML.format(title=self._title, hud=self._hud)
+                return _SPLASH_HTML.format(title=self._title)
             if self._html is not None:
                 return self._html
-            return _LIVE_HTML.format(title=self._title, hud=self._hud)
+            if self._started_mode == "user":
+                return _LIVE_USER_HTML.format(
+                    title=self._title,
+                    width=self._image_size[1], height=self._image_size[0],
+                )
+            return _LIVE_AI_HTML.format(title=self._title, hud=self._hud)
 
         @self.app.route("/start", methods=["POST"])
         def _start() -> Response:
+            mode = request.form.get("mode", "ai").strip().lower()
+            if mode not in ("ai", "user"):
+                mode = "ai"
+            with self._lock:
+                self._started_mode = mode
             self._start_event.set()
             return redirect(url_for("_index"))
 
@@ -131,18 +351,100 @@ class MJPEGServer:
                 mimetype="multipart/x-mixed-replace; boundary=frame",
             )
 
-    def wait_for_start(self, timeout: float | None = None) -> bool:
-        """Block until the Start button is pressed (or ``timeout`` expires).
+        @self.app.route("/state")
+        def _state() -> Response:
+            with self._lock:
+                payload = {
+                    "state": self._fsm_state,
+                    "countdown_s": self._fsm_countdown_s,
+                    "terminal": self._fsm_terminal,
+                    "result": self._fsm_result,
+                }
+            return Response(json.dumps(payload), mimetype="application/json")
 
-        Returns ``True`` if started, ``False`` on timeout. When the server
-        was constructed without ``use_start_trigger=True`` the event is
-        pre-set so this returns immediately.
-        """
+        @self.app.route("/submit", methods=["POST"])
+        def _submit() -> Response:
+            body = request.get_json(silent=True) or {}
+            bbox = body.get("bbox")
+            if not (
+                isinstance(bbox, list) and len(bbox) == 4
+                and all(isinstance(v, int | float) for v in bbox)
+            ):
+                return Response('{"ok":false,"error":"malformed bbox"}',
+                                status=400, mimetype="application/json")
+            with self._lock:
+                self._submission = {
+                    "bbox": [float(v) for v in bbox],
+                    "ts": time.time(),
+                }
+            return Response('{"ok":true}', mimetype="application/json")
+
+        @self._sock.route("/ws/input")
+        def _ws_input(ws) -> None:  # noqa: ANN001 - flask_sock's ws type is dynamic
+            try:
+                while True:
+                    msg = ws.receive()
+                    if msg is None:
+                        break
+                    try:
+                        ev = json.loads(msg)
+                    except Exception:
+                        continue
+                    key = str(ev.get("key", "")).lower()
+                    evtype = ev.get("type")
+                    if not key:
+                        continue
+                    with self._lock:
+                        if evtype == "keydown":
+                            self._pressed.add(key)
+                        elif evtype == "keyup":
+                            self._pressed.discard(key)
+            except Exception:
+                return
+
+    # ── Public API (mission loop) ───────────────────────────────────
+
+    def wait_for_start(self, timeout: float | None = None) -> bool:
         return self._start_event.wait(timeout=timeout)
 
     @property
     def started(self) -> bool:
         return self._start_event.is_set()
+
+    @property
+    def started_mode(self) -> str:
+        with self._lock:
+            return self._started_mode
+
+    def set_fsm_state(
+        self,
+        state: str,
+        countdown_s: float | None,
+        terminal: bool = False,
+        result: str | None = None,
+    ) -> None:
+        """Mission loop reports FSM state each tick; the page polls /state."""
+        with self._lock:
+            self._fsm_state = state
+            self._fsm_countdown_s = countdown_s
+            self._fsm_terminal = terminal
+            self._fsm_result = result
+
+    def get_pressed_keys(self) -> frozenset[str]:
+        """Snapshot of keys currently held by the user."""
+        with self._lock:
+            return frozenset(self._pressed)
+
+    def get_submission(self) -> dict | None:
+        """Most recent bbox submission, if any. Mission loop clears it."""
+        with self._lock:
+            return self._submission
+
+    def clear_submission(self) -> None:
+        with self._lock:
+            self._submission = None
+
+    # ── MJPEG plumbing ──────────────────────────────────────────────
 
     def _generate(self):
         while True:
@@ -162,12 +464,10 @@ class MJPEGServer:
             )
 
     def push(self, frame: np.ndarray) -> None:
-        """Set the latest frame. Expected BGR uint8."""
         with self._lock:
             self._frame = frame
 
     def start(self, host: str = "0.0.0.0", port: int = 5000) -> None:
-        """Start Flask on a daemon thread."""
         def _run() -> None:
             self.app.run(host=host, port=port, threaded=True, use_reloader=False)
         threading.Thread(target=_run, daemon=True).start()

--- a/skycop/dashboard/mjpeg.py
+++ b/skycop/dashboard/mjpeg.py
@@ -31,16 +31,129 @@ from flask import Flask, Response, redirect, request, url_for
 from flask_sock import Sock
 
 _LIVE_AI_HTML = """<!DOCTYPE html>
-<html><head><title>{title}</title>
+<html><head><title>{title} — AI Pursuit</title>
 <style>
-  body {{ margin: 0; background: #111; color: #eee; font-family: monospace; }}
+  body {{ margin: 0; background: #111; color: #eee;
+          font-family: ui-monospace, Menlo, Consolas, monospace; overflow: hidden; }}
   img  {{ width: 100vw; height: 100vh; object-fit: contain; display: block; }}
-  #hud {{ position: fixed; top: 10px; left: 10px; background: rgba(0,0,0,0.7);
-          padding: 8px 12px; border-radius: 6px; font-size: 13px; }}
+  #border {{ position: fixed; inset: 0; pointer-events: none; z-index: 30;
+             box-sizing: border-box; border: 8px solid transparent;
+             transition: border-color 0.3s ease; }}
+  #border.fleeing {{ border-color: #e14; }}
+  #border.roaming {{ border-color: #f90; }}
+  #border.parking {{ border-color: #fc3; }}
+  #border.parked  {{ border-color: #4e8; }}
+  #panel {{ position: fixed; top: 14px; left: 50%; transform: translateX(-50%);
+            background: rgba(0,0,0,0.85); padding: 14px 28px; border-radius: 10px;
+            font-size: 16px; display: flex; flex-direction: column; gap: 6px;
+            align-items: center; min-width: 320px; border: 3px solid #333;
+            text-align: center; }}
+  #panel .state {{ font-size: 28px; font-weight: bold; letter-spacing: 0.12em; }}
+  #panel .hint  {{ font-size: 14px; color: #ccc; }}
+  #panel.fleeing {{ border-color: #e14; background: rgba(225, 17, 68, 0.15); }}
+    #panel.fleeing .state {{ color: #f66; }}
+  #panel.roaming {{ border-color: #f90; background: rgba(255, 153, 0, 0.15); }}
+    #panel.roaming .state {{ color: #fa4; }}
+  #panel.parking {{ border-color: #fc3; background: rgba(255, 204, 51, 0.15); }}
+    #panel.parking .state {{ color: #fd6; }}
+  #panel.parked  {{ border-color: #4e8; background: rgba(68, 238, 136, 0.2); }}
+    #panel.parked  .state {{ color: #6f8; }}
+  #flash {{ position: fixed; top: 38%; left: 50%;
+            transform: translate(-50%, -50%) scale(0.9);
+            padding: 28px 68px; border-radius: 14px; font-size: 48px;
+            font-weight: bold; letter-spacing: 0.15em;
+            background: rgba(0,0,0,0.7); border: 4px solid;
+            opacity: 0; pointer-events: none; z-index: 40;
+            transition: opacity 0.25s ease, transform 0.25s ease; }}
+  #flash.show {{ opacity: 1; transform: translate(-50%, -50%) scale(1.0); }}
+  #flash.fleeing {{ border-color: #e14; color: #f66; }}
+  #flash.roaming {{ border-color: #f90; color: #fa4; }}
+  #flash.parking {{ border-color: #fc3; color: #fd6; }}
+  #flash.parked  {{ border-color: #4e8; color: #6f8; }}
+  #end {{ position: fixed; inset: 0; background: rgba(0,0,0,0.85);
+          display: none; align-items: center; justify-content: center;
+          flex-direction: column; gap: 1.5rem; z-index: 50; }}
+  #end.show {{ display: flex; }}
+  #end h1 {{ margin: 0; font-size: 2.2rem; }}
+  #end h1.win {{ color: #7fd; }} #end h1.lose {{ color: #f66; }}
+  #end p  {{ margin: 0; color: #ccc; max-width: 30rem; text-align: center; }}
+  #end a  {{ background: #7fd; color: #111; padding: 0.75rem 1.75rem;
+             text-decoration: none; border-radius: 0.5rem; font-family: inherit;
+             font-weight: bold; letter-spacing: 0.05em; }}
 </style>
 </head><body>
 <img src="/stream"/>
-<div id="hud">{hud}</div>
+<div id="border" class="fleeing"></div>
+<div id="panel" class="fleeing">
+  <div class="state">FLEEING</div>
+  <div class="hint">Autonomous pursuit · {hud}</div>
+</div>
+<div id="flash" class="fleeing">FLEEING</div>
+<div id="end">
+  <h1 id="end-title">—</h1>
+  <p id="end-detail">—</p>
+  <a href="/menu">Back to menu</a>
+</div>
+<script>
+const panel = document.getElementById('panel');
+const border = document.getElementById('border');
+const flash = document.getElementById('flash');
+const stateLabel = panel.querySelector('.state');
+const hintLabel = panel.querySelector('.hint');
+const endPanel = document.getElementById('end');
+const endTitle = document.getElementById('end-title');
+const endDetail = document.getElementById('end-detail');
+const hints = {{
+  fleeing: 'Suspect fleeing — drone pursuing',
+  roaming: 'Suspect roaming — drone pursuing',
+  parking: 'Suspect parking — drone holding',
+  parked:  'Suspect parked — AI confirming',
+}};
+const flashLabels = {{
+  fleeing: 'FLEEING', roaming: 'ROAMING', parking: 'PARKING', parked: 'PARKED',
+}};
+let lastState = null;
+let flashTimer = null;
+function showFlash(newState) {{
+  flash.textContent = flashLabels[newState] || newState.toUpperCase();
+  flash.className = newState;
+  void flash.offsetWidth;
+  flash.classList.add('show');
+  if (flashTimer) clearTimeout(flashTimer);
+  flashTimer = setTimeout(() => {{ flash.classList.remove('show'); }}, 1200);
+}}
+async function pollState() {{
+  try {{
+    const r = await fetch('/state'); const s = await r.json();
+    stateLabel.textContent = s.state.toUpperCase();
+    hintLabel.textContent = hints[s.state] || '';
+    if (s.state === 'parked' && s.countdown_s != null) {{
+      hintLabel.textContent = `AI confirming · ${{s.countdown_s.toFixed(1)}}s`;
+    }}
+    panel.className = s.state;
+    border.className = s.state;
+    if (lastState !== null && s.state !== lastState && !s.terminal) {{
+      showFlash(s.state);
+    }}
+    lastState = s.state;
+    if (s.terminal) {{
+      endPanel.classList.add('show');
+      const win = s.result === 'ai_pass';
+      endTitle.textContent = win ? 'Pursuit confirmed' : 'Suspect lost';
+      endTitle.className = win ? 'win' : 'lose';
+      const detail = {{
+        ai_pass: 'AI locked the parked suspect. Autonomous pursuit succeeded.',
+        timeout_lose: 'The 60-second confirmation window expired with no lock. The suspect is gone.',
+      }};
+      endDetail.textContent = detail[s.result] || 'Round ended.';
+    }} else {{
+      endPanel.classList.remove('show');
+    }}
+  }} catch (e) {{}}
+}}
+setInterval(pollState, 250);
+pollState();
+</script>
 </body></html>"""
 
 _LIVE_USER_HTML = """<!DOCTYPE html>
@@ -54,16 +167,43 @@ _LIVE_USER_HTML = """<!DOCTYPE html>
   canvas {{ position: absolute; inset: 0; width: 100%; height: 100%;
             cursor: crosshair; pointer-events: none; }}
   canvas.active {{ pointer-events: auto; }}
-  #panel {{ position: fixed; top: 12px; left: 12px;
-            background: rgba(0,0,0,0.82); padding: 10px 14px; border-radius: 8px;
-            font-size: 14px; display: flex; flex-direction: column; gap: 4px;
-            min-width: 220px; border: 2px solid #333; }}
-  #panel .state {{ font-size: 17px; font-weight: bold; letter-spacing: 0.07em; }}
-  #panel .hint  {{ font-size: 12px; color: #bbb; }}
-  #panel.fleeing {{ border-color: #e14; }} #panel.fleeing .state {{ color: #f66; }}
-  #panel.roaming {{ border-color: #f90; }} #panel.roaming .state {{ color: #fa4; }}
-  #panel.parking {{ border-color: #fc3; }} #panel.parking .state {{ color: #fd6; }}
-  #panel.parked  {{ border-color: #4e8; }} #panel.parked  .state {{ color: #6f8; }}
+  /* Full-viewport coloured border — always visible, matches suspect state. */
+  #border {{ position: fixed; inset: 0; pointer-events: none; z-index: 30;
+             box-sizing: border-box; border: 8px solid transparent;
+             transition: border-color 0.3s ease; }}
+  #border.fleeing {{ border-color: #e14; }}
+  #border.roaming {{ border-color: #f90; }}
+  #border.parking {{ border-color: #fc3; }}
+  #border.parked  {{ border-color: #4e8; }}
+  /* Top-centre state banner — readable from the middle of the screen. */
+  #panel {{ position: fixed; top: 14px; left: 50%; transform: translateX(-50%);
+            background: rgba(0,0,0,0.85); padding: 14px 28px; border-radius: 10px;
+            font-size: 16px; display: flex; flex-direction: column; gap: 6px;
+            align-items: center; min-width: 320px; border: 3px solid #333;
+            text-align: center; }}
+  #panel .state {{ font-size: 28px; font-weight: bold; letter-spacing: 0.12em; }}
+  #panel .hint  {{ font-size: 14px; color: #ccc; }}
+  #panel.fleeing {{ border-color: #e14; background: rgba(225, 17, 68, 0.15); }}
+    #panel.fleeing .state {{ color: #f66; }}
+  #panel.roaming {{ border-color: #f90; background: rgba(255, 153, 0, 0.15); }}
+    #panel.roaming .state {{ color: #fa4; }}
+  #panel.parking {{ border-color: #fc3; background: rgba(255, 204, 51, 0.15); }}
+    #panel.parking .state {{ color: #fd6; }}
+  #panel.parked  {{ border-color: #4e8; background: rgba(68, 238, 136, 0.2); }}
+    #panel.parked  .state {{ color: #6f8; }}
+  /* Transition flash — big centred banner for ~1 s on state change. */
+  #flash {{ position: fixed; top: 38%; left: 50%;
+            transform: translate(-50%, -50%) scale(0.9);
+            padding: 28px 68px; border-radius: 14px; font-size: 48px;
+            font-weight: bold; letter-spacing: 0.15em;
+            background: rgba(0,0,0,0.7); border: 4px solid;
+            opacity: 0; pointer-events: none; z-index: 40;
+            transition: opacity 0.25s ease, transform 0.25s ease; }}
+  #flash.show {{ opacity: 1; transform: translate(-50%, -50%) scale(1.0); }}
+  #flash.fleeing {{ border-color: #e14; color: #f66; }}
+  #flash.roaming {{ border-color: #f90; color: #fa4; }}
+  #flash.parking {{ border-color: #fc3; color: #fd6; }}
+  #flash.parked  {{ border-color: #4e8; color: #6f8; }}
   #controls {{ position: fixed; top: 12px; right: 12px;
                background: rgba(0,0,0,0.75); padding: 10px 14px;
                border-radius: 8px; font-size: 12px; color: #bbb; line-height: 1.7; }}
@@ -89,10 +229,12 @@ _LIVE_USER_HTML = """<!DOCTYPE html>
   <img src="/stream"/>
   <canvas id="canvas"></canvas>
 </div>
+<div id="border" class="fleeing"></div>
 <div id="panel" class="fleeing">
   <div class="state">FLEEING</div>
   <div class="hint">connecting…</div>
 </div>
+<div id="flash" class="fleeing">FLEEING</div>
 <div id="controls">
   <b>W/S</b> forward · back<br>
   <b>A/D</b> strafe left · right<br>
@@ -182,6 +324,8 @@ submit.addEventListener('click', async () => {{
 
 // ── Game state polling ───────────────────────────────────────────
 const panel = document.getElementById('panel');
+const border = document.getElementById('border');
+const flash = document.getElementById('flash');
 const stateLabel = panel.querySelector('.state');
 const hintLabel = panel.querySelector('.hint');
 const endPanel = document.getElementById('end');
@@ -193,6 +337,20 @@ const hints = {{
   parking: 'Suspect parking — hold position',
   parked:  'Draw bbox · submit',
 }};
+const flashLabels = {{
+  fleeing: 'FLEEING', roaming: 'ROAMING', parking: 'PARKING', parked: 'PARKED',
+}};
+let lastState = null;
+let flashTimer = null;
+function showFlash(newState) {{
+  flash.textContent = flashLabels[newState] || newState.toUpperCase();
+  flash.className = newState;
+  // trigger reflow so the 'show' transition always plays
+  void flash.offsetWidth;
+  flash.classList.add('show');
+  if (flashTimer) clearTimeout(flashTimer);
+  flashTimer = setTimeout(() => {{ flash.classList.remove('show'); }}, 1200);
+}}
 async function pollState() {{
   try {{
     const r = await fetch('/state'); const s = await r.json();
@@ -202,6 +360,11 @@ async function pollState() {{
       hintLabel.textContent = `Draw bbox · submit · ${{s.countdown_s.toFixed(1)}}s`;
     }}
     panel.className = s.state;
+    border.className = s.state;
+    if (lastState !== null && s.state !== lastState && !s.terminal) {{
+      showFlash(s.state);
+    }}
+    lastState = s.state;
     // Canvas + submit enable only when PARKED
     if (s.state === 'parked' && !s.terminal) {{
       canvas.classList.add('active');
@@ -223,6 +386,10 @@ async function pollState() {{
         timeout_lose: 'The 60-second confirmation window expired with no submission. The suspect is gone.',
       }};
       endDetail.textContent = detail[s.result] || 'Round ended.';
+    }} else {{
+      // A fresh round was started (terminal cleared by the server) — hide
+      // the end modal so the new round is visible.
+      endPanel.classList.remove('show');
     }}
   }} catch (e) {{ /* server restarting or paused — keep polling */ }}
 }}
@@ -453,12 +620,22 @@ class MJPEGServer:
         with self._lock:
             self._submission = None
 
-    def reset_for_menu(self) -> None:
-        """Rearm the server for a fresh round: clear the start event, drop
-        held keys, clear any pending submission, and reset the FSM snapshot
-        so the page shows the splash menu again and ``wait_for_start()``
-        blocks until the user picks a mode a second time.
+    def rearm_start_event(self) -> None:
+        """Between-round rearm: clear the start event, drop any held keys,
+        and clear any pending submission — but **keep** the FSM snapshot
+        (state / terminal / result) so the prior round's end modal stays
+        visible until the user explicitly clicks "Back to menu".
         """
+        with self._lock:
+            self._start_event.clear()
+            self._pressed.clear()
+            self._submission = None
+            self._started_mode = "ai"
+
+    def reset_for_menu(self) -> None:
+        """Full reset — event + input + FSM snapshot + mode. Called from
+        the /menu route when the user explicitly chooses to return to the
+        splash. Causes any page on the live view to see fresh state."""
         with self._lock:
             self._start_event.clear()
             self._pressed.clear()

--- a/skycop/main.py
+++ b/skycop/main.py
@@ -32,9 +32,22 @@ def main() -> None:
     )
     server.start(port=port)
     log.info("live view + start page: http://localhost:%d", port)
-    log.info("waiting for start click…")
 
-    run_mission(cfg, mjpeg_server=server)
+    # Replay loop: each mission ends with a "Back to menu" link in the end
+    # modal. We rearm the server so the menu shows again, then block on the
+    # next start click. Ctrl-C in the terminal to quit the process.
+    round_num = 1
+    while True:
+        log.info("round %d — waiting for start click…", round_num)
+        try:
+            run_mission(cfg, mjpeg_server=server)
+        except KeyboardInterrupt:
+            log.info("KeyboardInterrupt — exiting")
+            return
+        except Exception:
+            log.exception("mission crashed — resetting for next round")
+        server.reset_for_menu()
+        round_num += 1
 
 
 if __name__ == "__main__":

--- a/skycop/main.py
+++ b/skycop/main.py
@@ -46,7 +46,10 @@ def main() -> None:
             return
         except Exception:
             log.exception("mission crashed — resetting for next round")
-        server.reset_for_menu()
+        # Between-round rearm: clears the start event so the next round
+        # blocks on wait_for_start, but keeps the prior round's end modal
+        # state visible to the page until the user clicks "Back to menu".
+        server.rearm_start_event()
         round_num += 1
 
 

--- a/skycop/main.py
+++ b/skycop/main.py
@@ -28,6 +28,7 @@ def main() -> None:
         title="SkyCop Pursuit",
         hud="AI drone pursuit · live MJPEG feed",
         use_start_trigger=True,
+        image_size=(int(cfg.camera.height), int(cfg.camera.width)),
     )
     server.start(port=port)
     log.info("live view + start page: http://localhost:%d", port)

--- a/skycop/mission.py
+++ b/skycop/mission.py
@@ -840,23 +840,21 @@ def run_mission(cfg, mjpeg_server: MJPEGServer | None = None) -> MissionResult:
 
                     # ── Overlay + live push ──────────────────────────────
                     # User mode: no tracker overlay, no GT bbox (user finds the
-                    # suspect themselves), no running accuracy (n/a).
+                    # suspect themselves), no running accuracy (n/a). FSM state
+                    # is shown by the big top-centre HTML panel, not the overlay.
                     running_id_accuracy = (
                         frames_id_correct / frames_suspect_visible
                         if frames_suspect_visible > 0 else None
                     )
-                    hud_extra = _fsm_hud_line(fsm_tick)
                     if mode == "user":
                         overlay = _render_mission_overlay(
                             frame_bgr, None, [], None, {},
                             frames_total, None, drone_to_suspect,
-                            hud_extra=hud_extra,
                         )
                     else:
                         overlay = _render_mission_overlay(
                             frame_bgr, gt_bbox, tracks, locked_track_id, track_scores,
                             frames_total, running_id_accuracy, drone_to_suspect,
-                            hud_extra=hud_extra,
                         )
                     if video_writer is not None:
                         video_writer.write(overlay)

--- a/skycop/mission.py
+++ b/skycop/mission.py
@@ -41,7 +41,14 @@ import carla
 import cv2
 import numpy as np
 
-from skycop.control import PursuitPID, TargetStateTracker
+from skycop.control import (
+    Pose,
+    PursuitPID,
+    TargetStateTracker,
+    UserDroneConfig,
+    UserDroneController,
+)
+from skycop.control.collision import apply_slide_along
 from skycop.cv.capture import weather_preset
 from skycop.cv.fingerprint import Fingerprint, extract, score
 from skycop.cv.gt_projection import (
@@ -320,6 +327,7 @@ def _choose_locked_track(
 
 def run_mission(cfg, mjpeg_server: MJPEGServer | None = None) -> MissionResult:
     mission_cfg = cfg.mission
+    mode = str(mission_cfg.get("mode", "ai")).lower()
     duration_s = float(mission_cfg.duration_s)
     altitude_m = float(mission_cfg.altitude_m)
     weather_name = str(mission_cfg.weather)
@@ -367,8 +375,6 @@ def run_mission(cfg, mjpeg_server: MJPEGServer | None = None) -> MissionResult:
     trace_path = run_dir / "trace.jsonl"
 
     weights_path = Path(cfg.training.project) / cfg.training.name / "weights" / "best.pt"
-    if not weights_path.exists():
-        raise FileNotFoundError(f"Fine-tuned weights missing: {weights_path}. Run exp 08.")
 
     client = connect(host=cfg.carla.host, port=cfg.carla.port)
     world = client.get_world()
@@ -378,11 +384,17 @@ def run_mission(cfg, mjpeg_server: MJPEGServer | None = None) -> MissionResult:
 
     # Start trigger (v0a): mission blocks here until the user clicks
     # "Start pursuit" on the MJPEG page (or instantly if the server wasn't
-    # constructed with use_start_trigger=True).
+    # constructed with use_start_trigger=True). The server also tells us
+    # which mode the user picked on the menu — we honour that over cfg.
     if mjpeg_server is not None and not mjpeg_server.started:
         log.info("mission paused — waiting for /start click on the MJPEG page…")
         mjpeg_server.wait_for_start()
-        log.info("start received; bringing up the scene")
+        mode = mjpeg_server.started_mode or mode
+        log.info("start received — mode=%s", mode)
+
+    # YOLO weights only required in AI mode (pipeline is disabled in user mode).
+    if mode == "ai" and not weights_path.exists():
+        raise FileNotFoundError(f"Fine-tuned weights missing: {weights_path}. Run exp 08.")
 
     K = build_camera_matrix(int(cfg.camera.width), int(cfg.camera.height), float(cfg.camera.fov))
     image_size = (int(cfg.camera.height), int(cfg.camera.width))
@@ -417,15 +429,18 @@ def run_mission(cfg, mjpeg_server: MJPEGServer | None = None) -> MissionResult:
             )
             actors.append(rgb_cam)
 
-            adapter = ByteTrackAdapter(
-                weights=str(weights_path),
-                tracker_yaml=str(cfg.tracking.tracker_yaml),
-                conf_threshold=float(cfg.detector.conf_threshold),
-                iou_threshold=float(cfg.detector.iou_threshold),
-                input_size=int(cfg.training.imgsz),
-                device=str(cfg.training.device),
-                fp16=bool(cfg.training.half),
-            )
+            # YOLO + ByteTrack only in AI mode (skipped in user mode).
+            adapter: ByteTrackAdapter | None = None
+            if mode == "ai":
+                adapter = ByteTrackAdapter(
+                    weights=str(weights_path),
+                    tracker_yaml=str(cfg.tracking.tracker_yaml),
+                    conf_threshold=float(cfg.detector.conf_threshold),
+                    iou_threshold=float(cfg.detector.iou_threshold),
+                    input_size=int(cfg.training.imgsz),
+                    device=str(cfg.training.device),
+                    fp16=bool(cfg.training.half),
+                )
 
             log.info("altitude pinned to mission.altitude_m=%.1fm (v0a bump — adaptive altitude is issue #45)", altitude_m)
 
@@ -462,12 +477,29 @@ def run_mission(cfg, mjpeg_server: MJPEGServer | None = None) -> MissionResult:
                 drone_pos_world[0], drone_pos_world[1], drone_pos_world[2],
             )
 
-            pid_x = PursuitPID(Kp=flight_Kp, Ki=flight_Ki, Kd=flight_Kd,
-                               output_clamp=flight_clamp, integral_clamp=flight_int_clamp)
-            pid_y = PursuitPID(Kp=flight_Kp, Ki=flight_Ki, Kd=flight_Kd,
-                               output_clamp=flight_clamp, integral_clamp=flight_int_clamp)
-            target_tracker = TargetStateTracker(window_size=ff_window)
-            ticks_since_lock = 0   # counter for hold-last-known
+            # Flight PID + feedforward + HLK — AI mode only.
+            pid_x = pid_y = None
+            target_tracker = None
+            ticks_since_lock = 0
+            if mode == "ai":
+                pid_x = PursuitPID(Kp=flight_Kp, Ki=flight_Ki, Kd=flight_Kd,
+                                   output_clamp=flight_clamp, integral_clamp=flight_int_clamp)
+                pid_y = PursuitPID(Kp=flight_Kp, Ki=flight_Ki, Kd=flight_Kd,
+                                   output_clamp=flight_clamp, integral_clamp=flight_int_clamp)
+                target_tracker = TargetStateTracker(window_size=ff_window)
+
+            # User-mode controller — body-frame snappy WASD-QE (v0c).
+            user_ctrl: UserDroneController | None = None
+            drone_yaw_rad = math.radians(float(suspect_tf0.rotation.yaw))
+            if mode == "user":
+                user_cfg = UserDroneConfig(
+                    max_speed_mps=float(flight_clamp),
+                    altitude_rate_mps=5.0,
+                    yaw_rate_deg_s=60.0,
+                    min_altitude_m=5.0,
+                )
+                user_ctrl = UserDroneController(cfg=user_cfg)
+                log.info("user mode — WASD + QE + Shift/Ctrl controls active")
 
             dt = float(cfg.carla.fixed_delta_seconds)
 
@@ -506,8 +538,13 @@ def run_mission(cfg, mjpeg_server: MJPEGServer | None = None) -> MissionResult:
             t0 = time.perf_counter()
             try:
                 for tick in range(target_ticks):
-                    # Camera yaw follows suspect body yaw via GT (gimbal PID deferred to PR 2b).
-                    suspect_yaw = float(suspect.get_transform().rotation.yaw)
+                    # ── Camera / drone pose for this tick ──────────────
+                    # AI mode: camera yaw follows suspect body yaw via GT.
+                    # User mode: camera yaw = user-controlled drone yaw.
+                    if mode == "user":
+                        camera_yaw_deg = math.degrees(drone_yaw_rad)
+                    else:
+                        camera_yaw_deg = float(suspect.get_transform().rotation.yaw)
                     pose = carla.Transform(
                         carla.Location(
                             float(drone_pos_world[0]),
@@ -516,7 +553,7 @@ def run_mission(cfg, mjpeg_server: MJPEGServer | None = None) -> MissionResult:
                         ),
                         carla.Rotation(
                             pitch=float(cfg.camera.pitch),
-                            yaw=suspect_yaw,
+                            yaw=camera_yaw_deg,
                             roll=0.0,
                         ),
                     )
@@ -563,117 +600,141 @@ def run_mission(cfg, mjpeg_server: MJPEGServer | None = None) -> MissionResult:
                                 frames_in_frame += 1
                                 suspect_fully_in_frame = True
 
-                    # Detect + track.
-                    tracks = adapter.update(frame_bgr)
-
-                    # Fingerprint bootstrap (first tick where a tracker box overlaps GT).
-                    if seed_fp is None and gt_bbox is not None:
-                        for t in tracks:
-                            if t.track_id is None:
-                                continue
-                            if iou_xyxy(t.bbox, gt_bbox) >= iou_gate:
-                                seed_fp = extract(frame_bgr, t.bbox, bins=hsv_bins)
-                                if seed_fp.is_valid():
-                                    locked_track_id = t.track_id
-                                    initial_lock_frame = frames_total
-                                    initial_lock_track_id = t.track_id
-                                    log.info("initial lock: frame=%d track_id=%d",
-                                             frames_total, t.track_id)
-                                    break
-
-                    # Fingerprint matching + sticky rebind.
+                    # ── AI mode: detect + track + fingerprint + flight PID ──
+                    # User mode: skip all of this — user flies via WASDQE.
+                    tracks = []
                     track_scores: dict[int, float] = {}
-                    if seed_fp is not None:
-                        for t in tracks:
-                            if t.track_id is None:
-                                continue
-                            cand_fp = extract(frame_bgr, t.bbox, bins=hsv_bins)
-                            track_scores[t.track_id] = score(seed_fp, cand_fp)
-                        locked_track_id = _choose_locked_track(
-                            track_scores, locked_track_id, rebind_threshold, stickiness
-                        )
-
-                    # Identify the "correct" tracker box for metric bookkeeping: the one
-                    # whose bbox has IoU ≥ gate with the GT projection.
                     gt_matched_track_id: int | None = None
-                    if gt_bbox is not None:
-                        best_gt_iou = 0.0
-                        for t in tracks:
-                            if t.track_id is None:
-                                continue
-                            gt_iou = iou_xyxy(t.bbox, gt_bbox)
-                            if gt_iou > best_gt_iou and gt_iou >= iou_gate:
-                                best_gt_iou = gt_iou
-                                gt_matched_track_id = t.track_id
-
                     locked_track = None
-                    if locked_track_id is not None:
-                        frames_locked += 1
-                        locked_track = next(
-                            (t for t in tracks if t.track_id == locked_track_id), None
-                        )
-
-                    # id_accuracy: on GT-visible frames, did we lock the right track_id?
-                    if suspect_visible and gt_matched_track_id is not None:
-                        if locked_track_id == gt_matched_track_id:
-                            frames_id_correct += 1
-
-                    # Legacy IoU correctness (for continuity with Mission v0 summary).
-                    if (
-                        locked_track is not None
-                        and gt_bbox is not None
-                        and iou_xyxy(locked_track.bbox, gt_bbox) >= iou_gate
-                    ):
-                        frames_iou_correct += 1
-
-                    # ── Flight control ───────────────────────────────────
-                    # Estimate target world position from locked track's bbox center
-                    # (pixel → ground-plane inverse projection).
-                    target_xy_world: tuple[float, float] | None = None
-                    if locked_track is not None:
-                        u = 0.5 * (locked_track.x1 + locked_track.x2)
-                        v = 0.5 * (locked_track.y1 + locked_track.y2)
-                        target_xy_world = pixel_to_world_on_ground(
-                            u, v, K, cam_to_world, ground_z=ground_z,
-                        )
-
                     center_offset_px = 0.0
                     velocity_cmd_magnitude = 0.0
-                    ff_vx = 0.0
-                    ff_vy = 0.0
 
-                    if target_xy_world is not None:
-                        ticks_since_lock = 0
-                        tx, ty = target_xy_world
-                        target_tracker.update(float(tick) * dt, tx, ty)
+                    if mode == "ai":
+                        assert adapter is not None
+                        assert pid_x is not None and pid_y is not None
+                        assert target_tracker is not None
 
-                        # Velocity feedforward.
-                        if ff_enabled:
-                            v_est = target_tracker.velocity
-                            if v_est is not None:
-                                ff_vx = ff_scale * v_est[0]
-                                ff_vy = ff_scale * v_est[1]
+                        tracks = adapter.update(frame_bgr)
 
-                        err_x = tx - drone_pos_world[0]
-                        err_y = ty - drone_pos_world[1]
-                        vx_cmd = pid_x.step(err_x, dt, feedforward=ff_vx)
-                        vy_cmd = pid_y.step(err_y, dt, feedforward=ff_vy)
+                        # Fingerprint bootstrap (first tick where a tracker box overlaps GT).
+                        if seed_fp is None and gt_bbox is not None:
+                            for t in tracks:
+                                if t.track_id is None:
+                                    continue
+                                if iou_xyxy(t.bbox, gt_bbox) >= iou_gate:
+                                    seed_fp = extract(frame_bgr, t.bbox, bins=hsv_bins)
+                                    if seed_fp.is_valid():
+                                        locked_track_id = t.track_id
+                                        initial_lock_frame = frames_total
+                                        initial_lock_track_id = t.track_id
+                                        log.info("initial lock: frame=%d track_id=%d",
+                                                 frames_total, t.track_id)
+                                        break
 
-                        drone_pos_world[0] += vx_cmd * dt
-                        drone_pos_world[1] += vy_cmd * dt
-                        velocity_cmd_magnitude = float(np.hypot(vx_cmd, vy_cmd))
+                        # Fingerprint matching + sticky rebind.
+                        if seed_fp is not None:
+                            for t in tracks:
+                                if t.track_id is None:
+                                    continue
+                                cand_fp = extract(frame_bgr, t.bbox, bins=hsv_bins)
+                                track_scores[t.track_id] = score(seed_fp, cand_fp)
+                            locked_track_id = _choose_locked_track(
+                                track_scores, locked_track_id, rebind_threshold, stickiness
+                            )
 
-                        # Centre-offset for the trace (distance of locked bbox centre from image centre).
-                        img_cx = 0.5 * (image_size[1] - 1)
-                        img_cy = 0.5 * (image_size[0] - 1)
-                        center_offset_px = float(np.hypot(u - img_cx, v - img_cy))
-                    else:
-                        # Hold-last-known (SIM-17). Freeze drone pose; decay integrator state.
-                        ticks_since_lock += 1
-                        if ticks_since_lock >= hlk_trigger:
-                            pid_x.reset()
-                            pid_y.reset()
-                            target_tracker.reset()
+                        # Identify the "correct" tracker box for metric bookkeeping: the one
+                        # whose bbox has IoU ≥ gate with the GT projection.
+                        if gt_bbox is not None:
+                            best_gt_iou = 0.0
+                            for t in tracks:
+                                if t.track_id is None:
+                                    continue
+                                gt_iou = iou_xyxy(t.bbox, gt_bbox)
+                                if gt_iou > best_gt_iou and gt_iou >= iou_gate:
+                                    best_gt_iou = gt_iou
+                                    gt_matched_track_id = t.track_id
+
+                        if locked_track_id is not None:
+                            frames_locked += 1
+                            locked_track = next(
+                                (t for t in tracks if t.track_id == locked_track_id), None
+                            )
+
+                        # id_accuracy: on GT-visible frames, did we lock the right track_id?
+                        if (
+                            suspect_visible
+                            and gt_matched_track_id is not None
+                            and locked_track_id == gt_matched_track_id
+                        ):
+                            frames_id_correct += 1
+
+                        # Legacy IoU correctness (for continuity with Mission v0 summary).
+                        if (
+                            locked_track is not None
+                            and gt_bbox is not None
+                            and iou_xyxy(locked_track.bbox, gt_bbox) >= iou_gate
+                        ):
+                            frames_iou_correct += 1
+
+                        # Flight control: pixel → ground-plane inverse projection.
+                        target_xy_world: tuple[float, float] | None = None
+                        if locked_track is not None:
+                            u = 0.5 * (locked_track.x1 + locked_track.x2)
+                            v = 0.5 * (locked_track.y1 + locked_track.y2)
+                            target_xy_world = pixel_to_world_on_ground(
+                                u, v, K, cam_to_world, ground_z=ground_z,
+                            )
+
+                        ff_vx = 0.0
+                        ff_vy = 0.0
+                        if target_xy_world is not None:
+                            ticks_since_lock = 0
+                            tx, ty = target_xy_world
+                            target_tracker.update(float(tick) * dt, tx, ty)
+                            if ff_enabled:
+                                v_est = target_tracker.velocity
+                                if v_est is not None:
+                                    ff_vx = ff_scale * v_est[0]
+                                    ff_vy = ff_scale * v_est[1]
+                            err_x = tx - drone_pos_world[0]
+                            err_y = ty - drone_pos_world[1]
+                            vx_cmd = pid_x.step(err_x, dt, feedforward=ff_vx)
+                            vy_cmd = pid_y.step(err_y, dt, feedforward=ff_vy)
+                            drone_pos_world[0] += vx_cmd * dt
+                            drone_pos_world[1] += vy_cmd * dt
+                            velocity_cmd_magnitude = float(np.hypot(vx_cmd, vy_cmd))
+
+                            # Centre-offset for the trace (locked bbox centre vs image centre).
+                            img_cx = 0.5 * (image_size[1] - 1)
+                            img_cy = 0.5 * (image_size[0] - 1)
+                            center_offset_px = float(np.hypot(u - img_cx, v - img_cy))
+                        else:
+                            # Hold-last-known (SIM-17). Freeze drone pose; decay integrator state.
+                            ticks_since_lock += 1
+                            if ticks_since_lock >= hlk_trigger:
+                                pid_x.reset()
+                                pid_y.reset()
+                                target_tracker.reset()
+
+                    elif mode == "user":
+                        assert user_ctrl is not None
+                        assert mjpeg_server is not None
+                        pressed = mjpeg_server.get_pressed_keys()
+                        current_pose = Pose(
+                            x=float(drone_pos_world[0]),
+                            y=float(drone_pos_world[1]),
+                            z=float(drone_pos_world[2]),
+                            yaw_rad=drone_yaw_rad,
+                        )
+                        intended = user_ctrl.step(current_pose, pressed, dt)
+                        safe = apply_slide_along(world, current_pose, intended)
+                        drone_pos_world[0] = safe.x
+                        drone_pos_world[1] = safe.y
+                        drone_pos_world[2] = safe.z
+                        drone_yaw_rad = safe.yaw_rad
+                        velocity_cmd_magnitude = float(
+                            math.hypot(safe.x - current_pose.x, safe.y - current_pose.y) / dt
+                        )
 
                     # ── Suspect FSM step ─────────────────────────────────
                     suspect_tf_now = suspect.get_transform()
@@ -735,17 +796,68 @@ def run_mission(cfg, mjpeg_server: MJPEGServer | None = None) -> MissionResult:
                             acc.frames_in_frame += 1
                     acc.distance_samples.append(drone_to_suspect)
 
+                    # Push FSM state to MJPEG server (used by v0c user page for
+                    # the colour panel, submit enable, end modal).
+                    if mjpeg_server is not None:
+                        mjpeg_server.set_fsm_state(
+                            state=fsm_tick.state.value,
+                            countdown_s=fsm_tick.countdown_s,
+                            terminal=bool(fsm_tick.terminal),
+                            result=fsm_tick.submission,
+                        )
+
+                    # User-mode submission grading — only while in PARKED.
+                    if (
+                        mode == "user"
+                        and mjpeg_server is not None
+                        and fsm_tick.state == SuspectState.PARKED
+                        and not fsm_tick.terminal
+                    ):
+                        sub = mjpeg_server.get_submission()
+                        if sub is not None:
+                            mjpeg_server.clear_submission()
+                            passed = False
+                            if gt_bbox is not None:
+                                bx1, by1, bx2, by2 = sub["bbox"]
+                                cx = 0.5 * (bx1 + bx2)
+                                cy = 0.5 * (by1 + by2)
+                                gx1, gy1, gx2, gy2 = gt_bbox
+                                passed = (gx1 <= cx <= gx2) and (gy1 <= cy <= gy2)
+                            fsm_submission = "user_pass" if passed else "user_fail"
+                            fsm_terminal_state = SuspectState.PARKED
+                            log.info(
+                                "user submission graded: %s (bbox=%s, gt=%s)",
+                                fsm_submission, sub["bbox"], gt_bbox,
+                            )
+                            mjpeg_server.set_fsm_state(
+                                state=fsm_tick.state.value,
+                                countdown_s=fsm_tick.countdown_s,
+                                terminal=True,
+                                result=fsm_submission,
+                            )
+                            # Write a final overlay frame + break the loop.
+                            # (overlay + trace happen below before break)
+
                     # ── Overlay + live push ──────────────────────────────
+                    # User mode: no tracker overlay, no GT bbox (user finds the
+                    # suspect themselves), no running accuracy (n/a).
                     running_id_accuracy = (
                         frames_id_correct / frames_suspect_visible
                         if frames_suspect_visible > 0 else None
                     )
                     hud_extra = _fsm_hud_line(fsm_tick)
-                    overlay = _render_mission_overlay(
-                        frame_bgr, gt_bbox, tracks, locked_track_id, track_scores,
-                        frames_total, running_id_accuracy, drone_to_suspect,
-                        hud_extra=hud_extra,
-                    )
+                    if mode == "user":
+                        overlay = _render_mission_overlay(
+                            frame_bgr, None, [], None, {},
+                            frames_total, None, drone_to_suspect,
+                            hud_extra=hud_extra,
+                        )
+                    else:
+                        overlay = _render_mission_overlay(
+                            frame_bgr, gt_bbox, tracks, locked_track_id, track_scores,
+                            frames_total, running_id_accuracy, drone_to_suspect,
+                            hud_extra=hud_extra,
+                        )
                     if video_writer is not None:
                         video_writer.write(overlay)
                     if mjpeg_server is not None:
@@ -782,6 +894,11 @@ def run_mission(cfg, mjpeg_server: MJPEGServer | None = None) -> MissionResult:
                     if fsm_tick.terminal:
                         fsm_submission = fsm_tick.submission
                         log.info("FSM terminal at tick %d: submission=%s",
+                                 tick, fsm_submission)
+                        break
+                    # User-mode bbox grading set fsm_submission out-of-band.
+                    if fsm_submission in ("user_pass", "user_fail"):
+                        log.info("User submission terminal at tick %d: %s",
                                  tick, fsm_submission)
                         break
             finally:

--- a/tests/test_user_drone.py
+++ b/tests/test_user_drone.py
@@ -1,0 +1,177 @@
+"""Unit tests for skycop.control.user_drone — pure-pose controller."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from skycop.control.user_drone import (
+    Pose,
+    UserDroneConfig,
+    UserDroneController,
+)
+
+
+def _ctrl(**overrides) -> UserDroneController:
+    cfg = UserDroneConfig(**overrides)
+    return UserDroneController(cfg=cfg)
+
+
+def _pose(x=0.0, y=0.0, z=25.0, yaw_rad=0.0) -> Pose:
+    return Pose(x=x, y=y, z=z, yaw_rad=yaw_rad)
+
+
+# ── Null input ────────────────────────────────────────────────────
+
+def test_no_keys_returns_unchanged_pose():
+    c = _ctrl()
+    p0 = _pose(x=1.0, y=2.0, z=25.0, yaw_rad=0.5)
+    p1 = c.step(p0, frozenset(), dt=0.05)
+    assert p1.x == p0.x
+    assert p1.y == p0.y
+    assert p1.z == p0.z
+    assert p1.yaw_rad == p0.yaw_rad
+
+
+def test_rejects_non_positive_dt():
+    c = _ctrl()
+    with pytest.raises(ValueError):
+        c.step(_pose(), {"w"}, dt=0.0)
+    with pytest.raises(ValueError):
+        c.step(_pose(), {"w"}, dt=-0.05)
+
+
+# ── Forward / back (drone heading follow) ─────────────────────────
+
+def test_w_moves_body_forward_at_yaw_zero():
+    c = _ctrl(max_speed_mps=10.0)
+    p1 = c.step(_pose(yaw_rad=0.0), {"w"}, dt=0.1)
+    # Yaw=0 → body-forward is world +X. 10 m/s * 0.1s = 1 m.
+    assert abs(p1.x - 1.0) < 1e-9
+    assert abs(p1.y) < 1e-9
+
+
+def test_w_at_yaw_90_moves_world_plus_y():
+    c = _ctrl(max_speed_mps=10.0)
+    p1 = c.step(_pose(yaw_rad=math.pi / 2), {"w"}, dt=0.1)
+    # Yaw=90° → body-forward is world +Y.
+    assert abs(p1.x) < 1e-9
+    assert abs(p1.y - 1.0) < 1e-9
+
+
+def test_s_moves_body_back():
+    c = _ctrl(max_speed_mps=10.0)
+    p1 = c.step(_pose(yaw_rad=0.0), {"s"}, dt=0.1)
+    assert abs(p1.x - (-1.0)) < 1e-9
+
+
+# ── Strafe ────────────────────────────────────────────────────────
+
+def test_d_strafes_body_right():
+    c = _ctrl(max_speed_mps=10.0)
+    # Yaw 0 → body +Y (right) is world -Y (CARLA left-handed convention
+    # our convention puts right = +sin(yaw + 90°) = +cos(yaw); we mapped
+    # D → (+right) → world (-sin(yaw), +cos(yaw)). At yaw 0: (0, +1)).
+    p1 = c.step(_pose(yaw_rad=0.0), {"d"}, dt=0.1)
+    assert abs(p1.x) < 1e-9
+    assert abs(p1.y - 1.0) < 1e-9
+
+
+def test_a_strafes_body_left():
+    c = _ctrl(max_speed_mps=10.0)
+    p1 = c.step(_pose(yaw_rad=0.0), {"a"}, dt=0.1)
+    assert abs(p1.x) < 1e-9
+    assert abs(p1.y - (-1.0)) < 1e-9
+
+
+# ── Diagonal normalisation ────────────────────────────────────────
+
+def test_diagonal_wd_is_speed_clamped():
+    c = _ctrl(max_speed_mps=10.0)
+    p1 = c.step(_pose(yaw_rad=0.0), {"w", "d"}, dt=0.1)
+    # W + D → body (1, 1) normalised to unit + scaled by speed = (0.707, 0.707) * 10 * 0.1
+    disp = math.hypot(p1.x, p1.y)
+    assert abs(disp - 1.0) < 1e-6
+
+
+def test_opposing_keys_cancel():
+    c = _ctrl()
+    p1 = c.step(_pose(), {"w", "s"}, dt=0.1)
+    assert abs(p1.x) < 1e-9
+    assert abs(p1.y) < 1e-9
+
+
+# ── Yaw ───────────────────────────────────────────────────────────
+
+def test_q_rotates_ccw():
+    c = _ctrl(yaw_rate_deg_s=90.0)
+    p1 = c.step(_pose(yaw_rad=0.0), {"q"}, dt=1.0)
+    # Q = yaw left. 90°/s * 1s → -π/2.
+    assert abs(p1.yaw_rad - (-math.pi / 2)) < 1e-6
+
+
+def test_e_rotates_cw():
+    c = _ctrl(yaw_rate_deg_s=90.0)
+    p1 = c.step(_pose(yaw_rad=0.0), {"e"}, dt=1.0)
+    assert abs(p1.yaw_rad - (math.pi / 2)) < 1e-6
+
+
+def test_qe_together_cancel():
+    c = _ctrl(yaw_rate_deg_s=90.0)
+    p1 = c.step(_pose(yaw_rad=0.3), {"q", "e"}, dt=1.0)
+    assert abs(p1.yaw_rad - 0.3) < 1e-9
+
+
+def test_yaw_wraps_to_negative_pi_plus_pi():
+    c = _ctrl(yaw_rate_deg_s=360.0)
+    p1 = c.step(_pose(yaw_rad=math.pi - 0.1), {"e"}, dt=1.0)
+    # yaw + 2π wraps; result should be inside (-π, π]
+    assert -math.pi < p1.yaw_rad <= math.pi
+
+
+# ── Altitude ──────────────────────────────────────────────────────
+
+def test_shift_ascends():
+    c = _ctrl(altitude_rate_mps=5.0)
+    p1 = c.step(_pose(z=25.0), {"shift"}, dt=0.2)
+    assert abs(p1.z - 26.0) < 1e-9
+
+
+def test_ctrl_descends():
+    c = _ctrl(altitude_rate_mps=5.0)
+    p1 = c.step(_pose(z=25.0), {"control"}, dt=0.2)
+    assert abs(p1.z - 24.0) < 1e-9
+
+
+def test_altitude_clamped_at_floor():
+    c = _ctrl(altitude_rate_mps=5.0, min_altitude_m=2.0)
+    p1 = c.step(_pose(z=3.0), {"control"}, dt=1.0)
+    # Would descend to -2 m but clamp at 2 m.
+    assert p1.z == 2.0
+
+
+# ── Case-insensitive + ignores unknowns ──────────────────────────
+
+def test_uppercase_keys_accepted():
+    c = _ctrl(max_speed_mps=10.0)
+    p1 = c.step(_pose(), {"W"}, dt=0.1)
+    assert abs(p1.x - 1.0) < 1e-9
+
+
+def test_unknown_keys_ignored():
+    c = _ctrl()
+    p1 = c.step(_pose(), {"x", "space", "tab"}, dt=0.1)
+    assert p1.x == 0.0 and p1.y == 0.0 and p1.z == 25.0
+
+
+# ── Integration: keep walking forward for 1 s ────────────────────
+
+def test_walking_forward_for_1s_covers_max_speed_metres():
+    c = _ctrl(max_speed_mps=20.0)
+    p = _pose()
+    dt = 0.05
+    for _ in range(20):
+        p = c.step(p, {"w"}, dt=dt)
+    assert abs(p.x - 20.0) < 1e-6
+    assert abs(p.y) < 1e-9


### PR DESCRIPTION
## Summary

Manual Pursuit mode — user flies the drone with WASD+QE, waits for the suspect to park, draws a bbox and submits within 60 s, graded by the same bbox-centre-in-GT rule as AI mode.

v0c play sessions:
- 3 user rounds across sessions: **2 user_pass + 1 user_fail** (deliberate off-target bbox to exercise the fail path).
- All three graded correctly. Bbox precision on wins: within ~5 px of GT corners.
- 1 AI round in the replay loop to confirm unified HUD works across modes.

## In scope

- **Control scheme B** (drone-heading follow): camera yaw = drone body yaw; W/S forward/back, A/D strafe, Q/E yaw 60°/s, Shift/Ctrl altitude. Snappy (no momentum).
- **WebSocket input** (flask-sock) — event-based keydown/keyup; mission loop snapshots pressed-set per tick.
- **Slide-along collision** (walls + ground) via world.cast_ray, normal estimated from hit-to-drone vector. Pass-through allow-list: Roads, RoadLines, Vehicles, Sky, NONE, Terrain.
- **Draw-bbox + Submit both gate on FSM PARKED** — HTML5 canvas overlay on MJPEG, redraw-until-submit, submit POSTs image-pixel bbox.
- **Unified state HUD (AI + user modes)** — full-viewport coloured border, top-centre state banner (FLEEING red / ROAMING orange / PARKING yellow / PARKED green with countdown), transition flash on every state change, polled via `GET /state` @ 250 ms.
- **Replay loop** — mission.run_mission wrapped in `while True`; `Back to menu` link routes through `/menu` which calls `reset_for_menu()` synchronously (closes a teardown race). Ctrl-C still exits cleanly.
- **AI pipeline strictly disabled in user mode** — YOLO/ByteTrack/fingerprint/flight-PID not constructed; no GT bbox or tracker boxes on overlay; user finds the suspect unaided.
- D-16 decision record in docs/design.md with rationale for every sub-decision.

## Test plan

- [x] `make test` — 147 tests (was 128; 19 new UserDroneController + 3 vendor smoke + misc). All pure, no CARLA.
- [x] `make lint` — clean.
- [x] End-to-end server smoke via curl — menu renders, POST /start mode=user redirects, user-mode page serves canvas + WS + /state + end modal.
- [x] Full CARLA playthrough — 2× user_pass + 1× user_fail via browser, AI round confirmed with unified HUD.

## Known limitations (deferred)

- **#45 adaptive altitude** — drone can still look "stuck" in AI mode near the Town10HD monorail (walkway occludes line of sight; locked track drifts to a colour-similar feature and the flight PID parks the drone at that wrong-target's ground projection). Handled in a separate branch as originally planned.
- Momentum flight model — snappy felt fine in playtest; momentum is v0d candidate.
- Gamepad input — v0d candidate.
- Post-mission results breakdown — end modal is minimal ("Pursuit confirmed / Suspect lost"). Richer post-round page is v0d.

## Decision record

D-16 in docs/design.md — mixed transitions already in D-14 carry over; new commitments are control-scheme-B, snappy/no-momentum, WebSocket input, slide-along collision, PARKED-gated drawing+submit, unified HUD across modes.