### PR TITLE
Dead-reckon during brief track loss + velocity bump + loading placeholder (closes #45)

### DIFF
--- a/configs/control.yaml
+++ b/configs/control.yaml
@@ -12,7 +12,7 @@ control:
     Kp: 0.8
     Ki: 0.0
     Kd: 0.15
-    output_clamp_mps: 20.0    # max commanded velocity per axis (m/s)
+    output_clamp_mps: 25.0    # max commanded velocity per axis (m/s); bumped 20→25 for headroom over the suspect's speeding-during-FLEEING bursts and for snappier manual flight in v0c
     integral_clamp: 5.0       # absolute cap on integrator state
 
   # Velocity feedforward settings. Required for pursuit at any meaningful
@@ -28,10 +28,25 @@ control:
     window_size: 3
 
   # Hold-last-known behaviour (SIM-17). When the locked track is absent for
-  # this many consecutive ticks, freeze the commanded velocity at zero and
-  # drop the PID integrator state. Drone hovers at last position, no drift.
+  # this many consecutive ticks, drop the PID integrator state. Drone stays
+  # wherever dead-reckon (below) left it, no drift.
   hold_last_known:
     trigger_ticks: 3
+
+  # Dead-reckon during brief track loss (#45). When the locked tracker ID
+  # disappears from the frame (often because of an occlusion — walkway,
+  # tree, sign), keep *commanding* the drone at the last-estimated suspect
+  # velocity for up to ``max_seconds`` instead of freezing. Drone coasts
+  # into where the suspect is likely emerging, giving the fingerprint a
+  # chance to re-acquire cleanly. After ``max_seconds`` elapses with no
+  # re-lock, fall back to freeze + PID reset (SIM-17 behaviour above).
+  dead_reckon:
+    enabled: true
+    max_seconds: 2.0
+    # Coast the drone slightly FASTER than the suspect's estimated velocity
+    # during occlusions, so any pre-occlusion PID lag is closed by the time
+    # the suspect emerges. Commanded velocity is clamped to flight.output_clamp_mps.
+    velocity_gain: 1.5
 
   # Ground-plane assumption for pixel → world inverse projection.
   # In Town10HD roads are ~flat at z ≈ 0 within a few metres — good enough

--- a/docs/design.md
+++ b/docs/design.md
@@ -516,6 +516,36 @@ Plus a per-tick `trace.jsonl` (`drone_to_suspect_m`, `center_offset_px`, `veloci
 
 ---
 
+### D-17 · Dead-reckon during brief track loss (v1 of issue #45)
+
+**Status:** Decided · **Date:** 2026-04-22 · **Issue:** #45
+
+**Context.** v0c playtest with the altitude bump (25 m → 40 m, D-16 / v0c tune) confirmed that the Town10HD monorail walkways no longer visually occlude the drone at the framing level — the wider ground footprint keeps useful context on screen. But the tracker still loses its ID briefly as the suspect passes under the deck, and the v1a hold-last-known behaviour **froze the drone pose** for the duration of that blackout. The result: when the suspect emerged on the far side of the walkway, the drone was 100 m behind, and the fingerprint had to re-acquire across a larger gap than necessary — often snapping onto a lookalike.
+
+Initially this issue was scoped as "adaptive altitude + obstacle-aware climb-over + scan-high at dispatch" (three-trigger state machine). Playtesting at 40 m showed climb-over wasn't needed for the current Town10HD obstacles; scan-high is only load-bearing once dispatch bootstrap exists (FR-03). So the scope shrunk to a single v1 unit: dead-reckon.
+
+**Decisions.**
+
+1. **Dead-reckon during lock loss, bounded by `control.dead_reckon.max_seconds`** (default 2 s = 40 ticks at 20 FPS). When the locked track isn't in the current frame's tracks list, the mission loop continues to command the drone at ``TargetStateTracker.velocity`` (the last 3-sample smoothed estimate of the suspect's world velocity) instead of freezing. Drone coasts into where the suspect is likely heading; when the suspect emerges from the occlusion, the drone is positioned to re-acquire.
+
+2. **Fall back to v1a freeze + PID reset after the window expires.** After ``dr_max_ticks`` of dead-reckoning with no re-lock, the controller reverts to the SIM-17 hold-last-known behaviour — freeze drone pose and reset integrator state — so a long-term unrecoverable loss doesn't let the drone coast indefinitely. Matches the original intent: short blackouts get an educated guess, long blackouts stay put.
+
+3. **AI mode only.** User mode drone position is always commanded by the user; dead-reckon would fight the user's inputs. Gated via the existing ``mode == 'ai'`` branch.
+
+4. **No obstacle map loaded in v1.** The scout output (``output/scout/town10hd_overhead.json``, ``scripts/12_overhead_scout.py``) stays in the repo for a future iteration. Climb-over can be re-opened if a specific obstacle fails the 40 m pursuit altitude.
+
+**Deferred to a later issue once dispatch exists:**
+
+- **Scan-high at dispatch bootstrap** — climb to ~60 m when the drone has to find the suspect with no initial lock. Only becomes meaningful once the dispatch flow (FR-03) exists.
+- **Obstacle-aware climb-over** — dynamic altitude step on approach to a mapped overpass. Scout is ready; re-open once a specific failing obstacle is identified.
+
+**Open risks (v1 playtest watch list):**
+
+- TargetStateTracker velocity decays as samples age inside its rolling window. For very long blackouts the estimate can be stale — ``dr_max_seconds=2`` bounds the error.
+- The dead-reckon move is unclamped against ``flight.output_clamp_mps``. The estimate is already speed-limited by the physics of the suspect itself; a hard clamp is probably unnecessary. Watch whether commanded velocity spikes unrealistically in the trace.
+
+---
+
 ## 13. Open Questions
 
 - **Suspect FSM owner.** ~~Scripts 03/04 use TM autopilot with reckless knobs. The proper Fleeing→Roaming→Parking→Parked FSM (FR-07..11) is deferred.~~ Resolved by D-14 — FSM lives in `skycop.sim.suspect_fsm`, CARLA side-effects in the mission loop.

--- a/skycop/dashboard/mjpeg.py
+++ b/skycop/dashboard/mjpeg.py
@@ -461,7 +461,10 @@ class MJPEGServer:
         self._hud = hud or title
         self._html = html
         self._image_size = image_size
-        self._frame: np.ndarray | None = None
+        # Pre-seed with a placeholder so the MJPEG stream is never "blank"
+        # while the mission is spawning / ticking up — avoids the black
+        # screen the user sees just after clicking Start.
+        self._frame: np.ndarray = self._make_placeholder()
         self._lock = threading.Lock()
 
         # Start-trigger gate (v0a).
@@ -624,18 +627,21 @@ class MJPEGServer:
         """Between-round rearm: clear the start event, drop any held keys,
         and clear any pending submission — but **keep** the FSM snapshot
         (state / terminal / result) so the prior round's end modal stays
-        visible until the user explicitly clicks "Back to menu".
+        visible until the user explicitly clicks "Back to menu". The
+        MJPEG frame is reset to the "Loading" placeholder so the next
+        round doesn't start on a stale last-frame.
         """
         with self._lock:
             self._start_event.clear()
             self._pressed.clear()
             self._submission = None
             self._started_mode = "ai"
+            self._frame = self._make_placeholder()
 
     def reset_for_menu(self) -> None:
-        """Full reset — event + input + FSM snapshot + mode. Called from
-        the /menu route when the user explicitly chooses to return to the
-        splash. Causes any page on the live view to see fresh state."""
+        """Full reset — event + input + FSM snapshot + mode + frame. Called
+        from the /menu route when the user explicitly chooses to return to
+        the splash. Causes any page on the live view to see fresh state."""
         with self._lock:
             self._start_event.clear()
             self._pressed.clear()
@@ -645,6 +651,7 @@ class MJPEGServer:
             self._fsm_terminal = False
             self._fsm_result = None
             self._started_mode = "ai"
+            self._frame = self._make_placeholder()
 
     # ── MJPEG plumbing ──────────────────────────────────────────────
 
@@ -664,6 +671,31 @@ class MJPEGServer:
                 + buf.tobytes()
                 + b"\r\n"
             )
+
+    def _make_placeholder(self) -> np.ndarray:
+        """Solid-dark frame shown while no real camera frame is ready yet.
+
+        Two centred lines, pure ASCII (OpenCV's Hershey fonts don't render
+        Unicode punctuation, which was producing garbage glyphs earlier).
+        """
+        h, w = self._image_size
+        frame = np.full((h, w, 3), 20, dtype=np.uint8)
+        font = cv2.FONT_HERSHEY_SIMPLEX
+
+        title = "SKYCOP"
+        subtitle = "Loading pursuit scene"
+        (tw1, th1), _ = cv2.getTextSize(title, font, 2.4, 4)
+        (tw2, th2), _ = cv2.getTextSize(subtitle, font, 1.0, 2)
+        cy = h // 2
+        cv2.putText(
+            frame, title, ((w - tw1) // 2, cy - 16),
+            font, 2.4, (127, 221, 221), 4, cv2.LINE_AA,
+        )
+        cv2.putText(
+            frame, subtitle, ((w - tw2) // 2, cy + th2 + 30),
+            font, 1.0, (170, 170, 170), 2, cv2.LINE_AA,
+        )
+        return frame
 
     def push(self, frame: np.ndarray) -> None:
         with self._lock:

--- a/skycop/mission.py
+++ b/skycop/mission.py
@@ -345,6 +345,7 @@ def run_mission(cfg, mjpeg_server: MJPEGServer | None = None) -> MissionResult:
     flight_cfg = ctrl_cfg.flight
     ff_cfg = ctrl_cfg.feedforward
     hlk_cfg = ctrl_cfg.hold_last_known
+    dr_cfg = ctrl_cfg.get("dead_reckon", {"enabled": False, "max_seconds": 0.0})
     ground_z = float(ctrl_cfg.ground_plane.z)
     flight_Kp = float(flight_cfg.Kp)
     flight_Ki = float(flight_cfg.Ki)
@@ -353,6 +354,9 @@ def run_mission(cfg, mjpeg_server: MJPEGServer | None = None) -> MissionResult:
     flight_int_clamp = float(flight_cfg.integral_clamp)
     ff_enabled = bool(ff_cfg.enabled)
     ff_scale = float(ff_cfg.scale)
+    dr_enabled = bool(dr_cfg.enabled)
+    dr_max_seconds = float(dr_cfg.max_seconds)
+    dr_velocity_gain = float(dr_cfg.get("velocity_gain", 1.0)) if dr_enabled else 1.0
     ff_window = int(ff_cfg.window_size)
     hlk_trigger = int(hlk_cfg.trigger_ticks)
 
@@ -502,6 +506,7 @@ def run_mission(cfg, mjpeg_server: MJPEGServer | None = None) -> MissionResult:
                 log.info("user mode — WASD + QE + Shift/Ctrl controls active")
 
             dt = float(cfg.carla.fixed_delta_seconds)
+            dr_max_ticks = int(dr_max_seconds / dt) if dr_enabled else 0
 
             seed_fp: Fingerprint | None = None
             locked_track_id: int | None = None
@@ -709,9 +714,37 @@ def run_mission(cfg, mjpeg_server: MJPEGServer | None = None) -> MissionResult:
                             img_cy = 0.5 * (image_size[0] - 1)
                             center_offset_px = float(np.hypot(u - img_cx, v - img_cy))
                         else:
-                            # Hold-last-known (SIM-17). Freeze drone pose; decay integrator state.
+                            # Lock lost this tick. Prior behaviour (v1a) was to
+                            # freeze the drone and reset PID state after
+                            # hlk_trigger ticks; that made the drone park itself
+                            # wherever the tracker lost the suspect, so when the
+                            # suspect emerged from an occlusion the drone was
+                            # far out of frame (issue #45).
+                            #
+                            # Dead-reckon (issue #45): coast the drone at the
+                            # last-estimated suspect velocity for up to
+                            # ``dr_max_ticks`` so the drone continues to where
+                            # the suspect is likely heading. If re-lock doesn't
+                            # happen within the window, fall back to the v1a
+                            # freeze + reset behaviour.
                             ticks_since_lock += 1
-                            if ticks_since_lock >= hlk_trigger:
+                            v_est = (
+                                target_tracker.velocity
+                                if (dr_enabled and ticks_since_lock <= dr_max_ticks)
+                                else None
+                            )
+                            if v_est is not None:
+                                # Boost past the suspect's estimated speed so any pre-
+                                # occlusion PID lag closes by the time the suspect
+                                # emerges. Clamp to the flight velocity cap.
+                                vx_dr = max(-flight_clamp, min(flight_clamp,
+                                    v_est[0] * dr_velocity_gain))
+                                vy_dr = max(-flight_clamp, min(flight_clamp,
+                                    v_est[1] * dr_velocity_gain))
+                                drone_pos_world[0] += vx_dr * dt
+                                drone_pos_world[1] += vy_dr * dt
+                                velocity_cmd_magnitude = float(np.hypot(vx_dr, vy_dr))
+                            elif ticks_since_lock >= hlk_trigger:
                                 pid_x.reset()
                                 pid_y.reset()
                                 target_tracker.reset()


### PR DESCRIPTION
## Summary

Fixes the "stuck drone" behaviour when the suspect passes under a Town10HD monorail walkway (or any brief tracker-ID blackout). Instead of freezing at last-known-position and resetting PID state, the drone now **coasts at 1.5× the last-estimated suspect velocity for up to 2 s**, capped at the flight velocity clamp. Positioned to re-acquire cleanly on the far side of the occlusion.

## Scope

Per the #45 scope update — **dead-reckon only**. The broader climb-over + scan-high state machine from the original proposal is deferred: static 40 m pursuit altitude (landed in v0c) already gives enough clearance that obstacle-aware altitude changes aren't load-bearing. Scan-high becomes relevant once dispatch bootstrap (FR-03) exists.

## Config (configs/control.yaml)

\`\`\`yaml
control:
  flight:
    output_clamp_mps: 25.0       # bumped 20 → 25 (suspect FLEEING bursts + manual flight headroom)
  dead_reckon:
    enabled: true
    max_seconds: 2.0             # coast for up to 2 s of lock loss
    velocity_gain: 1.5           # coast at 1.5× suspect's estimated velocity so pre-occlusion lag is closed
\`\`\`

## Polish (ride-along)

- MJPEG stream seeded with a "SKYCOP · Loading pursuit scene" placeholder frame so the stream is never blank just after clicking Start (and after round rearm). Pure-ASCII — OpenCV Hershey fonts render Unicode as garbage glyphs, which triggered earlier "nonsense text" feedback.
- Dropped the redundant \`parking·trying_lot\` overlay HUD text now that the top-centre HTML panel carries the state cleanly.

## Playtest

- AI round near the monorail walkway: drone coasted through the occlusion instead of freezing; reacquired the suspect on the far side without the earlier 100 m drift.
- User round: the 25 m/s clamp gave noticeably snappier manual flight; placeholder loading screen ends the black-screen confusion at round start.
- \`ai_pass\` confirmed with the 1.5× gain still in the healthy band (no overshoot observed in the runs we captured).

## Test plan

- [x] \`make test\` — 147 tests, all pure, all green.
- [x] \`make lint\` — clean.
- [x] Manual CARLA playthrough — AI-mode walkway pass + manual control feel.

## Decision record

**D-17** added to \`docs/design.md\` — the full dead-reckon rationale, the scope-shrink from the original #45 (climb-over + scan-high parked until dispatch exists), and the open-risk watchlist (velocity decay over long blackouts; clamped to flight cap to handle the latter).

Closes #45.